### PR TITLE
S6 Overlay Refactor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM oznu/s6-node
+FROM oznu/s6-node:6.11.0
 
 RUN apk add --no-cache git python make g++ libffi-dev openssl-dev avahi-compat-libdns_sd avahi-dev openrc dbus
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,6 @@ COPY default.config.json /home/root/homebridge
 
 VOLUME /homebridge
 
+ENV S6_KEEP_ENV=1
+
 COPY root /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:6.10.1-alpine
+FROM oznu/s6-node
 
-RUN apk add --no-cache tzdata curl git python make g++ libffi-dev openssl-dev avahi-compat-libdns_sd avahi-dev openrc dbus
+RUN apk add --no-cache git python make g++ libffi-dev openssl-dev avahi-compat-libdns_sd avahi-dev openrc dbus
 
 RUN yarn global add node-gyp
 RUN yarn global add homebridge
@@ -13,8 +13,4 @@ COPY default.config.json /home/root/homebridge
 
 VOLUME /homebridge
 
-RUN mkdir /init.d
-COPY init.d/ /init.d
-ENTRYPOINT ["/init.d/entrypoint.sh"]
-
-CMD ["homebridge", "-U", "/homebridge", "-P", "/homebridge/node_modules"]
+COPY root /

--- a/Dockerfile.raspberry-pi
+++ b/Dockerfile.raspberry-pi
@@ -1,11 +1,9 @@
-FROM resin/raspberry-pi-alpine-node:6.10-slim
+FROM oznu/s6-node:armhf
 
-RUN apk add --no-cache tzdata curl git python make g++ libffi-dev openssl-dev avahi-compat-libdns_sd avahi-dev openrc dbus
+RUN apk add --no-cache git python make g++ libffi-dev openssl-dev avahi-compat-libdns_sd avahi-dev openrc dbus
 
-RUN npm install -g yarn
-
-RUN npm install -g node-gyp
-RUN npm install -g homebridge
+RUN yarn global add node-gyp
+RUN yarn global add homebridge
 
 RUN mkdir /homebridge && mkdir -p /home/root/homebridge
 WORKDIR /homebridge
@@ -15,8 +13,6 @@ COPY default.config.json /home/root/homebridge
 
 VOLUME /homebridge
 
-RUN mkdir /init.d
-COPY init.d/ /init.d
-ENTRYPOINT ["/init.d/entrypoint.sh"]
+ENV S6_KEEP_ENV=1
 
-CMD ["homebridge", "-U", "/homebridge", "-P", "/homebridge/node_modules"]
+COPY root /

--- a/Dockerfile.raspberry-pi
+++ b/Dockerfile.raspberry-pi
@@ -1,4 +1,4 @@
-FROM oznu/s6-node:armhf-6.11.0
+FROM oznu/s6-node:6.11.0-armhf
 
 RUN apk add --no-cache git python make g++ libffi-dev openssl-dev avahi-compat-libdns_sd avahi-dev openrc dbus
 

--- a/Dockerfile.raspberry-pi
+++ b/Dockerfile.raspberry-pi
@@ -1,4 +1,4 @@
-FROM oznu/s6-node:armhf
+FROM oznu/s6-node:armhf-6.11.0
 
 RUN apk add --no-cache git python make g++ libffi-dev openssl-dev avahi-compat-libdns_sd avahi-dev openrc dbus
 

--- a/README.md
+++ b/README.md
@@ -13,14 +13,13 @@ Currently this will not work when using [Docker for Mac](https://docs.docker.com
 
 ## Usage
 
-Quick Setup:
-
 ```shell
-docker run
-  --net=host
-  --name=homebridge
-  -e TZ=<timezone>
-  -v </path/to/config>:/homebridge
+docker run \
+  --net=host \
+  --name=homebridge \
+  -e PUID=<UID> -e PGID=<GID> \
+  -e TZ=<timezone> \
+  -v </path/to/config>:/homebridge \
   oznu/homebridge
 ```
 
@@ -45,13 +44,26 @@ The parameters are split into two halves, separated by a colon, the left hand si
 * `--net=host` - Shares host networking with container, **required**.
 * `-v /homebridge` - The Homebridge config and plugin location.
 * `-e TZ` - for [timezone information](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) *e.g. Europe/London, etc*
+* `-e PGID=` for for GroupID - see below for explanation
+* `-e PUID=` for for UserID - see below for explanation
 
-## Config
+### User / Group Identifiers
+
+Sometimes when using data volumes (`-v` flags) permissions issues can arise between the host OS and the container. We avoid this issue by allowing you to specify the user `PUID` and group `PGID`. Ensure the data volume directory on the host is owned by the same user you specify and it will "just work".
+
+In this instance `PUID=1001` and `PGID=1001`. To find yours use `id user` as below:
+
+```
+  $ id <dockeruser>
+    uid=1001(dockeruser) gid=1001(dockergroup) groups=1001(dockergroup)
+```
+
+## Homebridge Config
 
 The Homebridge config file is located at ```</path/to/config>/config.json```
 This file will be created the first time you run the container with a sample [FakeBulb](https://www.npmjs.com/package/homebridge-fakebulb) accessory.
 
-## Plugins
+## Homebridge Plugins
 
 Plugins should be defined in the ```</path/to/config>/package.json``` file in the standard NPM format.
 This file will be created the first time you run the container with the [FakeBulb](https://www.npmjs.com/package/homebridge-fakebulb) module.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ services:
     network_mode: host
     environment:
       - TZ=Australia/Sydney
+      - PGID=911
+      - PUID=911
     volumes:
       - ./volumes/homebridge:/homebridge
 ```

--- a/init.d/set-timezone.sh
+++ b/init.d/set-timezone.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-# Depends on the tzdata package
-
-if [ $TZ ]; then
-    [ -f /usr/share/zoneinfo/$TZ ] && cp /usr/share/zoneinfo/$TZ /etc/localtime || echo "WARNING: $TZ is not a valid time zone."
-    [ -f /usr/share/zoneinfo/$TZ ] && echo "$TZ" >  /etc/timezone
-fi

--- a/root/etc/cont-init.d/50-plugins
+++ b/root/etc/cont-init.d/50-plugins
@@ -1,12 +1,4 @@
-#!/bin/sh
-
-/init.d/set-timezone.sh
-
-rm -rf /var/run/dbus.pid
-rm -rf /var/run/avahi-daemon//pid
-
-dbus-daemon --system
-avahi-daemon -D
+#!/usr/bin/with-contenv sh
 
 [ -f /homebridge/package.json ] || cp /home/root/homebridge/default.package.json /homebridge/package.json
 [ -f /homebridge/config.json ] || cp /home/root/homebridge/default.config.json /homebridge/config.json
@@ -16,6 +8,4 @@ npm prune
 echo "Installing plugins..."
 yarn install
 
-sleep 5
-
-exec "$@"
+chown -R abc:abc /homebridge

--- a/root/etc/cont-init.d/50-plugins
+++ b/root/etc/cont-init.d/50-plugins
@@ -3,9 +3,9 @@
 [ -f /homebridge/package.json ] || cp /home/root/homebridge/default.package.json /homebridge/package.json
 [ -f /homebridge/config.json ] || cp /home/root/homebridge/default.config.json /homebridge/config.json
 
-echo "Removing old plugins..."
+echo "Homebridge: Removing old plugins..."
 npm prune
-echo "Installing plugins..."
+echo "Homebridge: Installing plugins..."
 yarn install
 
 chown -R abc:abc /homebridge

--- a/root/etc/services.d/avahi/run
+++ b/root/etc/services.d/avahi/run
@@ -1,2 +1,8 @@
 #!/usr/bin/with-contenv sh
-avahi-daemon
+
+until [[ -e /var/run/dbus/system_bus_socket ]]; do
+  sleep 1s
+done
+
+echo "Starting Avahi daemon"
+exec avahi-daemon

--- a/root/etc/services.d/avahi/run
+++ b/root/etc/services.d/avahi/run
@@ -1,0 +1,2 @@
+#!/usr/bin/with-contenv sh
+avahi-daemon

--- a/root/etc/services.d/dbus/run
+++ b/root/etc/services.d/dbus/run
@@ -1,0 +1,2 @@
+#!/usr/bin/with-contenv sh
+dbus-daemon --system --nofork

--- a/root/etc/services.d/dbus/run
+++ b/root/etc/services.d/dbus/run
@@ -1,2 +1,4 @@
 #!/usr/bin/with-contenv sh
-dbus-daemon --system --nofork
+
+echo "Starting dbus-daemon"
+exec dbus-daemon --system --nofork

--- a/root/etc/services.d/homebridge/run
+++ b/root/etc/services.d/homebridge/run
@@ -1,0 +1,3 @@
+#!/usr/bin/with-contenv sh
+s6-svwait -t 7000 -U /var/run/s6/services/avahi
+s6-setuidgid abc homebridge -U /homebridge -P /homebridge/node_modules

--- a/root/etc/services.d/homebridge/run
+++ b/root/etc/services.d/homebridge/run
@@ -1,3 +1,3 @@
 #!/usr/bin/with-contenv sh
-s6-svwait -t 7000 -U /var/run/s6/services/avahi
+sleep 5
 s6-setuidgid abc homebridge -U /homebridge -P /homebridge/node_modules


### PR DESCRIPTION
- Implemented [s6-overlay](https://github.com/just-containers/s6-overlay) for container process management.
- Homebridge will no longer run as root.
- Provide the ability to set UID and GID for homebridge process and `/config` file ownership.
- Avahi and dbus processes are now monitored and will restart automatically if they quit unexpectedly.
- Upgraded Node.js to the latest LTS version (6.11.0).
- Base image is now the same for ARM and x86_64 builds.