### PR TITLE
Allow users to run custom script on container start

### DIFF
--- a/root/defaults/startup.sh
+++ b/root/defaults/startup.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+#
+# Docker Homebridge Custom Startup Script - oznu/homebridge
+#
+# This script can be used to customise the environment and will be executed as
+# the root user each time the container starts.
+#
+# If using this script to install Homebridge plugins please take note:
+#   * DO NOT install plugins using the global flag (-g)
+#   * ALWAYS install plugins using the npm --save flag, or just use yarn add
+#
+# Example:
+#
+# npm install --save homebridge-hue
+#
+# Consider using yarn to install plugins instead (it's much faster):
+#
+# yarn add homebridge-hue
+#

--- a/root/etc/cont-init.d/45-user-data
+++ b/root/etc/cont-init.d/45-user-data
@@ -1,0 +1,10 @@
+#!/usr/bin/with-contenv sh
+
+# create default files
+[[ -e /homebridge/package.json ]] || cp /defaults/package.json /homebridge/package.json
+[[ -e /homebridge/config.json ]] || cp /defaults/config.json /homebridge/config.json
+[[ -e /homebridge/startup.sh ]] || cp /defaults/startup.sh /homebridge/startup.sh
+
+# run user defined custom startup script
+chmod +x /homebridge/startup.sh
+exec /homebridge/startup.sh

--- a/root/etc/cont-init.d/50-plugins
+++ b/root/etc/cont-init.d/50-plugins
@@ -1,11 +1,12 @@
 #!/usr/bin/with-contenv sh
 
-[ -f /homebridge/package.json ] || cp /defaults/package.json /homebridge/package.json
-[ -f /homebridge/config.json ] || cp /defaults/config.json /homebridge/config.json
-
+# remove any plugins not in the package.json file
 echo "Homebridge: Removing old plugins..."
 npm prune
+
+# install plugins defined in the package.json file
 echo "Homebridge: Installing plugins..."
 yarn install
 
+# fix permissions
 chown -R abc:abc /homebridge


### PR DESCRIPTION
This pull request will allow the container to execute a user defined script on startup.

The script executed is located at `/homebridge/startup.sh` and will be created as a blank template the first time the container is run if it does not already exist.

Resolves #15 