### PR TITLE
Add Support for ffmpeg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM oznu/s6-node:8.9.4
-
+RUN set -x \
+    && add-apt-repository ppa:mc3man/trusty-media \
+    && apt-get update \
+    && apt-get dist-upgrade \
+    && apt-get install -y --no-install-recommends \
+        ffmpeg \ 
 RUN apk add --no-cache git python make g++ avahi-compat-libdns_sd avahi-dev dbus \
   && mkdir /homebridge
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 FROM oznu/s6-node:8.9.4
-RUN set -x \
-    && add-apt-repository ppa:mc3man/trusty-media \
-    && apt-get update \
-    && apt-get dist-upgrade \
-    && apt-get install -y --no-install-recommends \
-        ffmpeg \ 
+RUN apk add --update ffmpeg 
+RUN apk add ffmpeg-libs
 RUN apk add --no-cache git python make g++ avahi-compat-libdns_sd avahi-dev dbus \
   && mkdir /homebridge
 


### PR DESCRIPTION
This adds support for Homebridge-nest-cam and Homebridge-camera-ffmpeg. Both of which require ffmpeg. This update has it install ffmpeg and the related ffmpeg libraries. (I tested this with homebridge-nest-cam and it worked). Let me know if you need anything else for me