### PR TITLE
removing nano to keep prod image clean

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 ARG S6_ARCH
 FROM oznu/s6-node:10.16.0-${S6_ARCH:-amd64}
 
-RUN apk add --no-cache git python make g++ avahi-compat-libdns_sd avahi-dev dbus \
-    iputils sudo nano \
+RUN apk add --no-cache \
+    git python make g++ \
+    avahi-compat-libdns_sd avahi-dev dbus \
+    iputils sudo  \
   && chmod 4755 /bin/ping \
   && mkdir /homebridge \
   && npm set global-style=true \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -2,8 +2,10 @@ ARG S6_ARCH
 FROM oznu/s6-node:10.16.0-debian-${S6_ARCH:-amd64}
 
 RUN apt-get update \
-  && apt-get install -y git python make g++ libnss-mdns avahi-discover libavahi-compat-libdnssd-dev \
-    inetutils-ping sudo nano \
+  && apt-get install -y \
+    git python make g++ libnss-mdns \
+    avahi-discover libavahi-compat-libdnssd-dev \
+    inetutils-ping sudo \
   && apt-get clean \
   && rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/* \
   && chmod 4755 /bin/ping \


### PR DESCRIPTION
I would prefer to exclude non-production packages on a production image. People who need editing on a live container can install nano (or vi) when they need it, or using startup.sh