### PR TITLE
Add GitHub Container Registry Images Mirror

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
           - name: amd64
             os: ubuntu-latest
             TARGET_IMAGE: oznu/homebridge
-            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}/homebridge
+            GITHUB_TARGET_IMAGE: ghcr.io/${{github.repository}}
             S6_ARCH: amd64
             DOCKERFILE: Dockerfile
             AVAHI: "0"
@@ -25,7 +25,7 @@ jobs:
           - name: ubuntu-amd64
             os: ubuntu-latest
             TARGET_IMAGE: oznu/homebridge
-            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}/homebridge
+            GITHUB_TARGET_IMAGE: ghcr.io/${{github.repository}}
             S6_ARCH: amd64
             DOCKERFILE: Dockerfile.ubuntu
             AVAHI: "1"
@@ -34,7 +34,7 @@ jobs:
           - name: ubuntu-no-avahi-amd64
             os: ubuntu-latest
             TARGET_IMAGE: oznu/homebridge
-            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}/homebridge           
+            GITHUB_TARGET_IMAGE: ghcr.io/${{github.repository}}       
             S6_ARCH: amd64
             DOCKERFILE: Dockerfile.ubuntu
             AVAHI: "0"
@@ -45,7 +45,7 @@ jobs:
           - name: arm32v6
             os: ubuntu-latest
             TARGET_IMAGE: oznu/homebridge
-            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}/homebridge
+            GITHUB_TARGET_IMAGE: ghcr.io/${{github.repository}}
             S6_ARCH: armhf
             DOCKERFILE: Dockerfile
             AVAHI: "0"
@@ -56,7 +56,7 @@ jobs:
           - name: ubuntu-arm32v7
             os: ubuntu-latest
             TARGET_IMAGE: oznu/homebridge
-            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}/homebridge
+            GITHUB_TARGET_IMAGE: ghcr.io/${{github.repository}}
             S6_ARCH: armhf
             DOCKERFILE: Dockerfile.ubuntu
             AVAHI: "1"
@@ -65,7 +65,7 @@ jobs:
           - name: ubuntu-no-avahi-arm32v7
             os: ubuntu-latest
             TARGET_IMAGE: oznu/homebridge
-            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}/homebridge            
+            GITHUB_TARGET_IMAGE: ghcr.io/${{github.repository}}         
             S6_ARCH: armhf
             DOCKERFILE: Dockerfile.ubuntu
             AVAHI: "0"
@@ -76,7 +76,7 @@ jobs:
           - name: arm64v8
             os: ubuntu-latest
             TARGET_IMAGE: oznu/homebridge
-            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}/homebridge            
+            GITHUB_TARGET_IMAGE: ghcr.io/${{github.repository}}           
             S6_ARCH: aarch64
             DOCKERFILE: Dockerfile
             AVAHI: "0"
@@ -87,7 +87,7 @@ jobs:
           - name: ubuntu-arm64v8
             os: ubuntu-latest
             TARGET_IMAGE: oznu/homebridge
-            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}/homebridge
+            GITHUB_TARGET_IMAGE: ghcr.io/${{github.repository}}
             S6_ARCH: aarch64
             DOCKERFILE: Dockerfile.ubuntu
             AVAHI: "1"
@@ -96,7 +96,7 @@ jobs:
           - name: ubuntu-no-avahi-arm64v8
             os: ubuntu-latest
             TARGET_IMAGE: oznu/homebridge
-            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}/homebridge
+            GITHUB_TARGET_IMAGE: ghcr.io/${{github.repository}}
             S6_ARCH: aarch64
             DOCKERFILE: Dockerfile.ubuntu
             AVAHI: "0"
@@ -146,7 +146,7 @@ jobs:
     # Login to DockerHub
     - name: Login to GitHub
       run: |
-        echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://docker.pkg.github.com -u ${GITHUB_ACTOR} --password-stdin
+        echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${GITHUB_ACTOR} --password-stdin
 
     # push the image to github
     - name: Push Image to GitHub
@@ -206,7 +206,7 @@ jobs:
 
           # GitHub
           - name: github
-            TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}/homebridge
+            TARGET_IMAGE: ghcr.io/${{github.repository}}
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -238,7 +238,7 @@ jobs:
 
     - name: Login to github
       run: |
-        echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://docker.pkg.github.com -u ${GITHUB_ACTOR} --password-stdin
+        echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${GITHUB_ACTOR} --password-stdin
 
     # latest / main
     - name: latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -273,7 +273,7 @@ jobs:
         export MANIFEST_SUFFIX=$(if [ "${{ steps.get_branch.outputs.NAME }}" = "master" ]; then echo "ubuntu"; else echo "${{ steps.get_branch.outputs.NAME }}-ubuntu"; fi)
         export TAG_PREFIX=$(if [ "${{ steps.get_branch.outputs.NAME }}" = "master" ]; then echo "ubuntu"; else echo "${{ steps.get_branch.outputs.NAME }}-ubuntu"; fi)
         docker manifest create ${{ matrix.TARGET_IMAGE }}:$MANIFEST_SUFFIX ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-amd64 ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-arm32v7 ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-arm64v8
-        docker manifest annotate ${{ matrix.TARGET_IMAGE }}$MANIFEST_SUFFIX ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-arm32v7 --os=linux --arch=arm --variant=v7
+        docker manifest annotate ${{ matrix.TARGET_IMAGE }}:$MANIFEST_SUFFIX ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-arm32v7 --os=linux --arch=arm --variant=v7
         docker manifest annotate ${{ matrix.TARGET_IMAGE }}:$MANIFEST_SUFFIX ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-arm64v8 --os=linux --arch=arm64 --variant=v8
         docker manifest push ${{ matrix.TARGET_IMAGE }}:$MANIFEST_SUFFIX
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
           - name: amd64
             os: ubuntu-latest
             TARGET_IMAGE: oznu/homebridge
-            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}
+            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}/homebridge
             S6_ARCH: amd64
             DOCKERFILE: Dockerfile
             AVAHI: "0"
@@ -25,7 +25,7 @@ jobs:
           - name: ubuntu-amd64
             os: ubuntu-latest
             TARGET_IMAGE: oznu/homebridge
-            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}
+            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}/homebridge
             S6_ARCH: amd64
             DOCKERFILE: Dockerfile.ubuntu
             AVAHI: "1"
@@ -34,7 +34,7 @@ jobs:
           - name: ubuntu-no-avahi-amd64
             os: ubuntu-latest
             TARGET_IMAGE: oznu/homebridge
-            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}            
+            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}/homebridge           
             S6_ARCH: amd64
             DOCKERFILE: Dockerfile.ubuntu
             AVAHI: "0"
@@ -45,7 +45,7 @@ jobs:
           - name: arm32v6
             os: ubuntu-latest
             TARGET_IMAGE: oznu/homebridge
-            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}
+            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}/homebridge
             S6_ARCH: armhf
             DOCKERFILE: Dockerfile
             AVAHI: "0"
@@ -56,7 +56,7 @@ jobs:
           - name: ubuntu-arm32v7
             os: ubuntu-latest
             TARGET_IMAGE: oznu/homebridge
-            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}
+            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}/homebridge
             S6_ARCH: armhf
             DOCKERFILE: Dockerfile.ubuntu
             AVAHI: "1"
@@ -65,7 +65,7 @@ jobs:
           - name: ubuntu-no-avahi-arm32v7
             os: ubuntu-latest
             TARGET_IMAGE: oznu/homebridge
-            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}            
+            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}/homebridge            
             S6_ARCH: armhf
             DOCKERFILE: Dockerfile.ubuntu
             AVAHI: "0"
@@ -76,7 +76,7 @@ jobs:
           - name: arm64v8
             os: ubuntu-latest
             TARGET_IMAGE: oznu/homebridge
-            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}            
+            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}/homebridge            
             S6_ARCH: aarch64
             DOCKERFILE: Dockerfile
             AVAHI: "0"
@@ -87,7 +87,7 @@ jobs:
           - name: ubuntu-arm64v8
             os: ubuntu-latest
             TARGET_IMAGE: oznu/homebridge
-            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}
+            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}/homebridge
             S6_ARCH: aarch64
             DOCKERFILE: Dockerfile.ubuntu
             AVAHI: "1"
@@ -96,7 +96,7 @@ jobs:
           - name: ubuntu-no-avahi-arm64v8
             os: ubuntu-latest
             TARGET_IMAGE: oznu/homebridge
-            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}
+            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}/homebridge
             S6_ARCH: aarch64
             DOCKERFILE: Dockerfile.ubuntu
             AVAHI: "0"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,14 +135,14 @@ jobs:
         docker build -f ${{ matrix.DOCKERFILE }} ${{ steps.get_image_cache.outputs.IMAGE_CACHE }} --build-arg S6_ARCH=${{ matrix.S6_ARCH }} --build-arg AVAHI=${{ matrix.AVAHI }} -t ${{ matrix.TARGET_IMAGE }}:${{ steps.get_tag.outputs.NAME }} .
 
     # push the image to docker hub
-    - name: Push Image
+    - name: Push Image To GitHub
       if: github.repository == 'oznu/docker-homebridge'
       run: |
         echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
         docker push ${{ matrix.TARGET_IMAGE }}:${{ steps.get_tag.outputs.NAME }}
-
-    # push alternate tags
-    - name: Push Alternate Tags
+        
+    # push alternate tags to dockerhub
+    - name: Push Alternate Tags To DockerHub
       if: github.repository == 'oznu/docker-homebridge'
       run: |
         if [ -z "${{ matrix.ALT_SUFFIX }}" ]; then
@@ -155,6 +155,29 @@ jobs:
             docker push ${{ matrix.TARGET_IMAGE }}:$ALT_IMAGE_TAG;
           done
         fi
+
+    # push the image to github
+    - name: Push Image to GitHub
+      run: |
+        echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://docker.pkg.github.com -u ${GITHUB_ACTOR} --password-stdin
+        docker tag ${{ matrix.TARGET_IMAGE }}:${{ steps.get_tag.outputs.NAME }} ${{github.repository}}:${{ steps.get_tag.outputs.NAME }}
+        docker push 
+
+    # push alternate tags to github
+    - name: Push Alternate Tags To GitHub
+      run: |
+        echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://docker.pkg.github.com -u ${GITHUB_ACTOR} --password-stdin
+        if [ -z "${{ matrix.ALT_SUFFIX }}" ]; then
+          echo "No alternate tags set for this build.";
+        else
+          for ALT_SUFFIX_ENTRY in $(echo "${{ matrix.ALT_SUFFIX }}" | sed "s/,/ /g"); do
+            echo "Tagging with alternate tag '$ALT_SUFFIX_ENTRY'";
+            export ALT_IMAGE_TAG=$(if [ "${{ steps.get_branch.outputs.NAME }}" = "master" ]; then if [ "$ALT_SUFFIX_ENTRY" = "" ]; then echo "error"; else echo "$ALT_SUFFIX_ENTRY"; fi; else if [ "$ALT_SUFFIX_ENTRY" = "" ]; then echo "${{ steps.get_branch.outputs.NAME }}"; else echo "${{ steps.get_branch.outputs.NAME }}-$ALT_SUFFIX_ENTRY"; fi; fi);
+            docker tag ${{ matrix.TARGET_IMAGE }}:${{ steps.get_tag.outputs.NAME }} ${{github.repository}}:$ALT_IMAGE_TAG;
+            docker push ${{github.repository}}:$ALT_IMAGE_TAG;
+          done
+        fi
+     
 
   # generate and publish the docker manifest
   manifest: 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,11 +134,41 @@ jobs:
       run: |
         docker build -f ${{ matrix.DOCKERFILE }} ${{ steps.get_image_cache.outputs.IMAGE_CACHE }} --build-arg S6_ARCH=${{ matrix.S6_ARCH }} --build-arg AVAHI=${{ matrix.AVAHI }} -t ${{ matrix.TARGET_IMAGE }}:${{ steps.get_tag.outputs.NAME }} .
 
-    # push the image to docker hub
-    - name: Push Image To GitHub
+    # Login to DockerHub
+    - name: Login to GitHub
+      run: |
+        echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://docker.pkg.github.com -u ${GITHUB_ACTOR} --password-stdin
+
+    # push the image to github
+    - name: Push Image to GitHub
+      run: |
+        docker tag ${{ matrix.TARGET_IMAGE }}:${{ steps.get_tag.outputs.NAME }} ${{github.repository}}:${{ steps.get_tag.outputs.NAME }}
+        docker push 
+
+    # push alternate tags to github
+    - name: Push Alternate Tags To GitHub
+      run: |
+        if [ -z "${{ matrix.ALT_SUFFIX }}" ]; then
+          echo "No alternate tags set for this build.";
+        else
+          for ALT_SUFFIX_ENTRY in $(echo "${{ matrix.ALT_SUFFIX }}" | sed "s/,/ /g"); do
+            echo "Tagging with alternate tag '$ALT_SUFFIX_ENTRY'";
+            export ALT_IMAGE_TAG=$(if [ "${{ steps.get_branch.outputs.NAME }}" = "master" ]; then if [ "$ALT_SUFFIX_ENTRY" = "" ]; then echo "error"; else echo "$ALT_SUFFIX_ENTRY"; fi; else if [ "$ALT_SUFFIX_ENTRY" = "" ]; then echo "${{ steps.get_branch.outputs.NAME }}"; else echo "${{ steps.get_branch.outputs.NAME }}-$ALT_SUFFIX_ENTRY"; fi; fi);
+            docker tag ${{ matrix.TARGET_IMAGE }}:${{ steps.get_tag.outputs.NAME }} ${{github.repository}}:$ALT_IMAGE_TAG;
+            docker push ${{github.repository}}:$ALT_IMAGE_TAG;
+          done
+        fi
+     
+    # Login to DockerHub
+    - name: Login to DockerHub
       if: github.repository == 'oznu/docker-homebridge'
       run: |
         echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+    # push the image to dockerhub
+    - name: Push Image To GitHub
+      if: github.repository == 'oznu/docker-homebridge'
+      run: |
         docker push ${{ matrix.TARGET_IMAGE }}:${{ steps.get_tag.outputs.NAME }}
         
     # push alternate tags to dockerhub
@@ -155,29 +185,6 @@ jobs:
             docker push ${{ matrix.TARGET_IMAGE }}:$ALT_IMAGE_TAG;
           done
         fi
-
-    # push the image to github
-    - name: Push Image to GitHub
-      run: |
-        echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://docker.pkg.github.com -u ${GITHUB_ACTOR} --password-stdin
-        docker tag ${{ matrix.TARGET_IMAGE }}:${{ steps.get_tag.outputs.NAME }} ${{github.repository}}:${{ steps.get_tag.outputs.NAME }}
-        docker push 
-
-    # push alternate tags to github
-    - name: Push Alternate Tags To GitHub
-      run: |
-        echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://docker.pkg.github.com -u ${GITHUB_ACTOR} --password-stdin
-        if [ -z "${{ matrix.ALT_SUFFIX }}" ]; then
-          echo "No alternate tags set for this build.";
-        else
-          for ALT_SUFFIX_ENTRY in $(echo "${{ matrix.ALT_SUFFIX }}" | sed "s/,/ /g"); do
-            echo "Tagging with alternate tag '$ALT_SUFFIX_ENTRY'";
-            export ALT_IMAGE_TAG=$(if [ "${{ steps.get_branch.outputs.NAME }}" = "master" ]; then if [ "$ALT_SUFFIX_ENTRY" = "" ]; then echo "error"; else echo "$ALT_SUFFIX_ENTRY"; fi; else if [ "$ALT_SUFFIX_ENTRY" = "" ]; then echo "${{ steps.get_branch.outputs.NAME }}"; else echo "${{ steps.get_branch.outputs.NAME }}-$ALT_SUFFIX_ENTRY"; fi; fi);
-            docker tag ${{ matrix.TARGET_IMAGE }}:${{ steps.get_tag.outputs.NAME }} ${{github.repository}}:$ALT_IMAGE_TAG;
-            docker push ${{github.repository}}:$ALT_IMAGE_TAG;
-          done
-        fi
-     
 
   # generate and publish the docker manifest
   manifest: 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -203,12 +203,10 @@ jobs:
           # DockerHub
           - name: dockerhub
             TARGET_IMAGE: oznu/homebridge
-            LOGIN: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
           # GitHub
           - name: github
             TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}/homebridge
-            LOGIN: echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://docker.pkg.github.com -u ${GITHUB_ACTOR} --password-stdin
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -233,9 +231,15 @@ jobs:
         sudo service docker restart
 
     # login to registry
-    - name: Login
+    - name: Login to dockerhub
+      if: ${{ matrix.name }} == 'dockerhub'
       run: |
-        eval ${{ matrix.LOGIN }}
+        echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+    - name: Login to github
+      if: ${{ matrix.name }} == 'github'
+      run: |
+        echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://docker.pkg.github.com -u ${GITHUB_ACTOR} --password-stdin
 
     # latest / main
     - name: latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,7 +143,7 @@ jobs:
     - name: Push Image to GitHub
       run: |
         docker tag ${{ matrix.TARGET_IMAGE }}:${{ steps.get_tag.outputs.NAME }} ${{github.repository}}:${{ steps.get_tag.outputs.NAME }}
-        docker push 
+        docker push ${{github.repository}}:${{ steps.get_tag.outputs.NAME }}
 
     # push alternate tags to github
     - name: Push Alternate Tags To GitHub
@@ -166,7 +166,7 @@ jobs:
         echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
     # push the image to dockerhub
-    - name: Push Image To GitHub
+    - name: Push Image To Dockerhub
       if: github.repository == 'oznu/docker-homebridge'
       run: |
         docker push ${{ matrix.TARGET_IMAGE }}:${{ steps.get_tag.outputs.NAME }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -146,7 +146,7 @@ jobs:
     # Login to DockerHub
     - name: Login to GitHub
       run: |
-        echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${GITHUB_ACTOR} --password-stdin
+        echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
 
     # push the image to github
     - name: Push Image to GitHub
@@ -238,7 +238,7 @@ jobs:
 
     - name: Login to github
       run: |
-        echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${GITHUB_ACTOR} --password-stdin
+        echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
 
     # latest / main
     - name: latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
           - name: amd64
             os: ubuntu-latest
             TARGET_IMAGE: oznu/homebridge
+            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}
             S6_ARCH: amd64
             DOCKERFILE: Dockerfile
             AVAHI: "0"
@@ -24,6 +25,7 @@ jobs:
           - name: ubuntu-amd64
             os: ubuntu-latest
             TARGET_IMAGE: oznu/homebridge
+            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}
             S6_ARCH: amd64
             DOCKERFILE: Dockerfile.ubuntu
             AVAHI: "1"
@@ -32,6 +34,7 @@ jobs:
           - name: ubuntu-no-avahi-amd64
             os: ubuntu-latest
             TARGET_IMAGE: oznu/homebridge
+            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}            
             S6_ARCH: amd64
             DOCKERFILE: Dockerfile.ubuntu
             AVAHI: "0"
@@ -42,6 +45,7 @@ jobs:
           - name: arm32v6
             os: ubuntu-latest
             TARGET_IMAGE: oznu/homebridge
+            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}
             S6_ARCH: armhf
             DOCKERFILE: Dockerfile
             AVAHI: "0"
@@ -52,6 +56,7 @@ jobs:
           - name: ubuntu-arm32v7
             os: ubuntu-latest
             TARGET_IMAGE: oznu/homebridge
+            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}
             S6_ARCH: armhf
             DOCKERFILE: Dockerfile.ubuntu
             AVAHI: "1"
@@ -60,6 +65,7 @@ jobs:
           - name: ubuntu-no-avahi-arm32v7
             os: ubuntu-latest
             TARGET_IMAGE: oznu/homebridge
+            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}            
             S6_ARCH: armhf
             DOCKERFILE: Dockerfile.ubuntu
             AVAHI: "0"
@@ -70,6 +76,7 @@ jobs:
           - name: arm64v8
             os: ubuntu-latest
             TARGET_IMAGE: oznu/homebridge
+            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}            
             S6_ARCH: aarch64
             DOCKERFILE: Dockerfile
             AVAHI: "0"
@@ -80,6 +87,7 @@ jobs:
           - name: ubuntu-arm64v8
             os: ubuntu-latest
             TARGET_IMAGE: oznu/homebridge
+            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}
             S6_ARCH: aarch64
             DOCKERFILE: Dockerfile.ubuntu
             AVAHI: "1"
@@ -88,6 +96,7 @@ jobs:
           - name: ubuntu-no-avahi-arm64v8
             os: ubuntu-latest
             TARGET_IMAGE: oznu/homebridge
+            GITHUB_TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}
             S6_ARCH: aarch64
             DOCKERFILE: Dockerfile.ubuntu
             AVAHI: "0"
@@ -142,8 +151,8 @@ jobs:
     # push the image to github
     - name: Push Image to GitHub
       run: |
-        docker tag ${{ matrix.TARGET_IMAGE }}:${{ steps.get_tag.outputs.NAME }} ${{github.repository}}:${{ steps.get_tag.outputs.NAME }}
-        docker push ${{github.repository}}:${{ steps.get_tag.outputs.NAME }}
+        docker tag ${{ matrix.TARGET_IMAGE }}:${{ steps.get_tag.outputs.NAME }} ${{ matrix.GITHUB_TARGET_IMAGE }}:${{ steps.get_tag.outputs.NAME }}
+        docker push ${{ matrix.GITHUB_TARGET_IMAGE }}:${{ steps.get_tag.outputs.NAME }}
 
     # push alternate tags to github
     - name: Push Alternate Tags To GitHub
@@ -154,8 +163,8 @@ jobs:
           for ALT_SUFFIX_ENTRY in $(echo "${{ matrix.ALT_SUFFIX }}" | sed "s/,/ /g"); do
             echo "Tagging with alternate tag '$ALT_SUFFIX_ENTRY'";
             export ALT_IMAGE_TAG=$(if [ "${{ steps.get_branch.outputs.NAME }}" = "master" ]; then if [ "$ALT_SUFFIX_ENTRY" = "" ]; then echo "error"; else echo "$ALT_SUFFIX_ENTRY"; fi; else if [ "$ALT_SUFFIX_ENTRY" = "" ]; then echo "${{ steps.get_branch.outputs.NAME }}"; else echo "${{ steps.get_branch.outputs.NAME }}-$ALT_SUFFIX_ENTRY"; fi; fi);
-            docker tag ${{ matrix.TARGET_IMAGE }}:${{ steps.get_tag.outputs.NAME }} ${{github.repository}}:$ALT_IMAGE_TAG;
-            docker push ${{github.repository}}:$ALT_IMAGE_TAG;
+            docker tag ${{ matrix.TARGET_IMAGE }}:${{ steps.get_tag.outputs.NAME }} ${{ matrix.GITHUB_TARGET_IMAGE }}:$ALT_IMAGE_TAG;
+            docker push ${{ matrix.GITHUB_TARGET_IMAGE }}:$ALT_IMAGE_TAG;
           done
         fi
      

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -197,10 +197,22 @@ jobs:
 
   # generate and publish the docker manifest
   manifest: 
-    if: github.repository == 'oznu/docker-homebridge'
+    strategy:
+      matrix:
+        include:
+          # DockerHub
+          - name: dockerhub
+            TARGET_IMAGE: oznu/homebridge
+            LOGIN: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+          # GitHub
+          - name: github
+            TARGET_IMAGE: docker.pkg.github.com/${{github.repository}}/homebridge
+            LOGIN: echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://docker.pkg.github.com -u ${GITHUB_ACTOR} --password-stdin
     needs: build
     runs-on: ubuntu-latest
     steps:
+
     # checkout repo
     - uses: actions/checkout@v2
 
@@ -220,22 +232,20 @@ jobs:
         echo '{"experimental": true,"storage-driver": "overlay2","max-concurrent-downloads": 50,"max-concurrent-uploads": 50}' | sudo tee /etc/docker/daemon.json
         sudo service docker restart
 
-    # login to docker hub
+    # login to registry
     - name: Login
       run: |
-        echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+        eval ${{ matrix.LOGIN }}
 
     # latest / main
     - name: latest
-      env:
-        TARGET_IMAGE: oznu/homebridge
       run: |
         export MANIFEST_SUFFIX=$(if [ "${{ steps.get_branch.outputs.NAME }}" = "master" ]; then echo "latest"; else echo "${{ steps.get_branch.outputs.NAME }}"; fi)
         export TAG_PREFIX=$(if [ "${{ steps.get_branch.outputs.NAME }}" = "master" ]; then echo ""; else echo "${{ steps.get_branch.outputs.NAME }}-"; fi)
-        docker manifest create $TARGET_IMAGE:$MANIFEST_SUFFIX $TARGET_IMAGE:${TAG_PREFIX}amd64 $TARGET_IMAGE:${TAG_PREFIX}arm32v6 $TARGET_IMAGE:${TAG_PREFIX}arm64v8
-        docker manifest annotate $TARGET_IMAGE:$MANIFEST_SUFFIX $TARGET_IMAGE:${TAG_PREFIX}arm32v6 --os=linux --arch=arm --variant=v6
-        docker manifest annotate $TARGET_IMAGE:$MANIFEST_SUFFIX $TARGET_IMAGE:${TAG_PREFIX}arm64v8 --os=linux --arch=arm64 --variant=v8
-        docker manifest push $TARGET_IMAGE:$MANIFEST_SUFFIX
+        docker manifest create ${{ matrix.TARGET_IMAGE }}:$MANIFEST_SUFFIX ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}amd64 ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}arm32v6 ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}arm64v8
+        docker manifest annotate ${{ matrix.TARGET_IMAGE }}:$MANIFEST_SUFFIX ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}arm32v6 --os=linux --arch=arm --variant=v6
+        docker manifest annotate ${{ matrix.TARGET_IMAGE }}:$MANIFEST_SUFFIX ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}arm64v8 --os=linux --arch=arm64 --variant=v8
+        docker manifest push ${{ matrix.TARGET_IMAGE }}:$MANIFEST_SUFFIX
     
     # no-avahi
     - name: no-avahi
@@ -244,10 +254,10 @@ jobs:
       run: |
         export MANIFEST_SUFFIX=$(if [ "${{ steps.get_branch.outputs.NAME }}" = "master" ]; then echo "no-avahi"; else echo "${{ steps.get_branch.outputs.NAME }}-no-avahi"; fi)
         export TAG_PREFIX=$(if [ "${{ steps.get_branch.outputs.NAME }}" = "master" ]; then echo "no-avahi"; else echo "${{ steps.get_branch.outputs.NAME }}-no-avahi"; fi)
-        docker manifest create $TARGET_IMAGE:$MANIFEST_SUFFIX $TARGET_IMAGE:${TAG_PREFIX}-amd64 $TARGET_IMAGE:${TAG_PREFIX}-arm32v6 $TARGET_IMAGE:${TAG_PREFIX}-arm64v8
-        docker manifest annotate $TARGET_IMAGE:$MANIFEST_SUFFIX $TARGET_IMAGE:${TAG_PREFIX}-arm32v6 --os=linux --arch=arm --variant=v6
-        docker manifest annotate $TARGET_IMAGE:$MANIFEST_SUFFIX $TARGET_IMAGE:${TAG_PREFIX}-arm64v8 --os=linux --arch=arm64 --variant=v8
-        docker manifest push $TARGET_IMAGE:$MANIFEST_SUFFIX
+        docker manifest create ${{ matrix.TARGET_IMAGE }}:$MANIFEST_SUFFIX ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-amd64 ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-arm32v6 ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-arm64v8
+        docker manifest annotate ${{ matrix.TARGET_IMAGE }}:$MANIFEST_SUFFIX ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-arm32v6 --os=linux --arch=arm --variant=v6
+        docker manifest annotate ${{ matrix.TARGET_IMAGE }}:$MANIFEST_SUFFIX ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-arm64v8 --os=linux --arch=arm64 --variant=v8
+        docker manifest push ${{ matrix.TARGET_IMAGE }}:$MANIFEST_SUFFIX
 
     # ubuntu
     - name: ubuntu
@@ -256,10 +266,10 @@ jobs:
       run: |
         export MANIFEST_SUFFIX=$(if [ "${{ steps.get_branch.outputs.NAME }}" = "master" ]; then echo "ubuntu"; else echo "${{ steps.get_branch.outputs.NAME }}-ubuntu"; fi)
         export TAG_PREFIX=$(if [ "${{ steps.get_branch.outputs.NAME }}" = "master" ]; then echo "ubuntu"; else echo "${{ steps.get_branch.outputs.NAME }}-ubuntu"; fi)
-        docker manifest create $TARGET_IMAGE:$MANIFEST_SUFFIX $TARGET_IMAGE:${TAG_PREFIX}-amd64 $TARGET_IMAGE:${TAG_PREFIX}-arm32v7 $TARGET_IMAGE:${TAG_PREFIX}-arm64v8
-        docker manifest annotate $TARGET_IMAGE:$MANIFEST_SUFFIX $TARGET_IMAGE:${TAG_PREFIX}-arm32v7 --os=linux --arch=arm --variant=v7
-        docker manifest annotate $TARGET_IMAGE:$MANIFEST_SUFFIX $TARGET_IMAGE:${TAG_PREFIX}-arm64v8 --os=linux --arch=arm64 --variant=v8
-        docker manifest push $TARGET_IMAGE:$MANIFEST_SUFFIX
+        docker manifest create ${{ matrix.TARGET_IMAGE }}:$MANIFEST_SUFFIX ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-amd64 ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-arm32v7 ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-arm64v8
+        docker manifest annotate ${{ matrix.TARGET_IMAGE }}$MANIFEST_SUFFIX ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-arm32v7 --os=linux --arch=arm --variant=v7
+        docker manifest annotate ${{ matrix.TARGET_IMAGE }}:$MANIFEST_SUFFIX ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-arm64v8 --os=linux --arch=arm64 --variant=v8
+        docker manifest push ${{ matrix.TARGET_IMAGE }}:$MANIFEST_SUFFIX
 
     # ubuntu-no-avahi
     - name: ubuntu-no-avahi
@@ -268,10 +278,10 @@ jobs:
       run: |
         export MANIFEST_SUFFIX=$(if [ "${{ steps.get_branch.outputs.NAME }}" = "master" ]; then echo "ubuntu-no-avahi"; else echo "${{ steps.get_branch.outputs.NAME }}-ubuntu-no-avahi"; fi)
         export TAG_PREFIX=$(if [ "${{ steps.get_branch.outputs.NAME }}" = "master" ]; then echo "ubuntu-no-avahi"; else echo "${{ steps.get_branch.outputs.NAME }}-ubuntu-no-avahi"; fi)
-        docker manifest create $TARGET_IMAGE:$MANIFEST_SUFFIX $TARGET_IMAGE:${TAG_PREFIX}-amd64 $TARGET_IMAGE:${TAG_PREFIX}-arm32v7 $TARGET_IMAGE:${TAG_PREFIX}-arm64v8
-        docker manifest annotate $TARGET_IMAGE:$MANIFEST_SUFFIX $TARGET_IMAGE:${TAG_PREFIX}-arm32v7 --os=linux --arch=arm --variant=v7
-        docker manifest annotate $TARGET_IMAGE:$MANIFEST_SUFFIX $TARGET_IMAGE:${TAG_PREFIX}-arm64v8 --os=linux --arch=arm64 --variant=v8
-        docker manifest push $TARGET_IMAGE:$MANIFEST_SUFFIX
+        docker manifest create ${{ matrix.TARGET_IMAGE }}:$MANIFEST_SUFFIX ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-amd64 ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-arm32v7 ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-arm64v8
+        docker manifest annotate ${{ matrix.TARGET_IMAGE }}:$MANIFEST_SUFFIX ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-arm32v7 --os=linux --arch=arm --variant=v7
+        docker manifest annotate ${{ matrix.TARGET_IMAGE }}:$MANIFEST_SUFFIX ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-arm64v8 --os=linux --arch=arm64 --variant=v8
+        docker manifest push ${{ matrix.TARGET_IMAGE }}:$MANIFEST_SUFFIX
 
     # debian (now actually ubuntu)
     - name: debian
@@ -280,10 +290,10 @@ jobs:
       run: |
         export MANIFEST_SUFFIX=$(if [ "${{ steps.get_branch.outputs.NAME }}" = "master" ]; then echo "debian"; else echo "${{ steps.get_branch.outputs.NAME }}-debian"; fi)
         export TAG_PREFIX=$(if [ "${{ steps.get_branch.outputs.NAME }}" = "master" ]; then echo "debian"; else echo "${{ steps.get_branch.outputs.NAME }}-debian"; fi)
-        docker manifest create $TARGET_IMAGE:$MANIFEST_SUFFIX $TARGET_IMAGE:${TAG_PREFIX}-amd64 $TARGET_IMAGE:${TAG_PREFIX}-arm32v7 $TARGET_IMAGE:${TAG_PREFIX}-arm64v8
-        docker manifest annotate $TARGET_IMAGE:$MANIFEST_SUFFIX $TARGET_IMAGE:${TAG_PREFIX}-arm32v7 --os=linux --arch=arm --variant=v7
-        docker manifest annotate $TARGET_IMAGE:$MANIFEST_SUFFIX $TARGET_IMAGE:${TAG_PREFIX}-arm64v8 --os=linux --arch=arm64 --variant=v8
-        docker manifest push $TARGET_IMAGE:$MANIFEST_SUFFIX
+        docker manifest create ${{ matrix.TARGET_IMAGE }}:$MANIFEST_SUFFIX ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-amd64 ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-arm32v7 ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-arm64v8
+        docker manifest annotate ${{ matrix.TARGET_IMAGE }}:$MANIFEST_SUFFIX ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-arm32v7 --os=linux --arch=arm --variant=v7
+        docker manifest annotate ${{ matrix.TARGET_IMAGE }}:$MANIFEST_SUFFIX ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-arm64v8 --os=linux --arch=arm64 --variant=v8
+        docker manifest push ${{ matrix.TARGET_IMAGE }}:$MANIFEST_SUFFIX
 
     # debian-no-avahi (now actually ubuntu)
     - name: debian-no-avahi
@@ -292,7 +302,7 @@ jobs:
       run: |
         export MANIFEST_SUFFIX=$(if [ "${{ steps.get_branch.outputs.NAME }}" = "master" ]; then echo "debian-no-avahi"; else echo "${{ steps.get_branch.outputs.NAME }}-debian-no-avahi"; fi)
         export TAG_PREFIX=$(if [ "${{ steps.get_branch.outputs.NAME }}" = "master" ]; then echo "debian-no-avahi"; else echo "${{ steps.get_branch.outputs.NAME }}-debian-no-avahi"; fi)
-        docker manifest create $TARGET_IMAGE:$MANIFEST_SUFFIX $TARGET_IMAGE:${TAG_PREFIX}-amd64 $TARGET_IMAGE:${TAG_PREFIX}-arm32v7 $TARGET_IMAGE:${TAG_PREFIX}-arm64v8
-        docker manifest annotate $TARGET_IMAGE:$MANIFEST_SUFFIX $TARGET_IMAGE:${TAG_PREFIX}-arm32v7 --os=linux --arch=arm --variant=v7
-        docker manifest annotate $TARGET_IMAGE:$MANIFEST_SUFFIX $TARGET_IMAGE:${TAG_PREFIX}-arm64v8 --os=linux --arch=arm64 --variant=v8
-        docker manifest push $TARGET_IMAGE:$MANIFEST_SUFFIX
+        docker manifest create ${{ matrix.TARGET_IMAGE }}:$MANIFEST_SUFFIX ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-amd64 ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-arm32v7 ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-arm64v8
+        docker manifest annotate ${{ matrix.TARGET_IMAGE }}:$MANIFEST_SUFFIX ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-arm32v7 --os=linux --arch=arm --variant=v7
+        docker manifest annotate ${{ matrix.TARGET_IMAGE }}:$MANIFEST_SUFFIX ${{ matrix.TARGET_IMAGE }}:${TAG_PREFIX}-arm64v8 --os=linux --arch=arm64 --variant=v8
+        docker manifest push ${{ matrix.TARGET_IMAGE }}:$MANIFEST_SUFFIX

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -253,8 +253,6 @@ jobs:
     
     # no-avahi
     - name: no-avahi
-      env:
-        TARGET_IMAGE: oznu/homebridge
       run: |
         export MANIFEST_SUFFIX=$(if [ "${{ steps.get_branch.outputs.NAME }}" = "master" ]; then echo "no-avahi"; else echo "${{ steps.get_branch.outputs.NAME }}-no-avahi"; fi)
         export TAG_PREFIX=$(if [ "${{ steps.get_branch.outputs.NAME }}" = "master" ]; then echo "no-avahi"; else echo "${{ steps.get_branch.outputs.NAME }}-no-avahi"; fi)
@@ -265,8 +263,6 @@ jobs:
 
     # ubuntu
     - name: ubuntu
-      env:
-        TARGET_IMAGE: oznu/homebridge
       run: |
         export MANIFEST_SUFFIX=$(if [ "${{ steps.get_branch.outputs.NAME }}" = "master" ]; then echo "ubuntu"; else echo "${{ steps.get_branch.outputs.NAME }}-ubuntu"; fi)
         export TAG_PREFIX=$(if [ "${{ steps.get_branch.outputs.NAME }}" = "master" ]; then echo "ubuntu"; else echo "${{ steps.get_branch.outputs.NAME }}-ubuntu"; fi)
@@ -277,8 +273,6 @@ jobs:
 
     # ubuntu-no-avahi
     - name: ubuntu-no-avahi
-      env:
-        TARGET_IMAGE: oznu/homebridge
       run: |
         export MANIFEST_SUFFIX=$(if [ "${{ steps.get_branch.outputs.NAME }}" = "master" ]; then echo "ubuntu-no-avahi"; else echo "${{ steps.get_branch.outputs.NAME }}-ubuntu-no-avahi"; fi)
         export TAG_PREFIX=$(if [ "${{ steps.get_branch.outputs.NAME }}" = "master" ]; then echo "ubuntu-no-avahi"; else echo "${{ steps.get_branch.outputs.NAME }}-ubuntu-no-avahi"; fi)
@@ -289,8 +283,6 @@ jobs:
 
     # debian (now actually ubuntu)
     - name: debian
-      env:
-        TARGET_IMAGE: oznu/homebridge
       run: |
         export MANIFEST_SUFFIX=$(if [ "${{ steps.get_branch.outputs.NAME }}" = "master" ]; then echo "debian"; else echo "${{ steps.get_branch.outputs.NAME }}-debian"; fi)
         export TAG_PREFIX=$(if [ "${{ steps.get_branch.outputs.NAME }}" = "master" ]; then echo "debian"; else echo "${{ steps.get_branch.outputs.NAME }}-debian"; fi)
@@ -301,8 +293,6 @@ jobs:
 
     # debian-no-avahi (now actually ubuntu)
     - name: debian-no-avahi
-      env:
-        TARGET_IMAGE: oznu/homebridge
       run: |
         export MANIFEST_SUFFIX=$(if [ "${{ steps.get_branch.outputs.NAME }}" = "master" ]; then echo "debian-no-avahi"; else echo "${{ steps.get_branch.outputs.NAME }}-debian-no-avahi"; fi)
         export TAG_PREFIX=$(if [ "${{ steps.get_branch.outputs.NAME }}" = "master" ]; then echo "debian-no-avahi"; else echo "${{ steps.get_branch.outputs.NAME }}-debian-no-avahi"; fi)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -209,6 +209,7 @@ jobs:
             TARGET_IMAGE: ghcr.io/${{github.repository}}
     needs: build
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
 
     # checkout repo
@@ -239,6 +240,12 @@ jobs:
     - name: Login to github
       run: |
         echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+
+    # Stop if dockerhub and not the main repo
+    - name: Login to dockerhub
+      if: github.repository != 'oznu/docker-homebridge' && matrix.name == 'dockerhub'
+      run: exit 1
+        
 
     # latest / main
     - name: latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -232,12 +232,11 @@ jobs:
 
     # login to registry
     - name: Login to dockerhub
-      if: ${{ matrix.name }} == 'dockerhub'
+      if: github.repository == 'oznu/docker-homebridge'
       run: |
         echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
 
     - name: Login to github
-      if: ${{ matrix.name }} == 'github'
       run: |
         echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://docker.pkg.github.com -u ${GITHUB_ACTOR} --password-stdin
 


### PR DESCRIPTION
With DockerHub now implementing limits, I was looking for this image on Github Container Registry.

When merged this PR will also push the image to GCR along with the DockerHub variant.

This does require the Repo owner to add a GitHub personal access token as the secret "CR_PAT" it will need the Read&Write packages permission on the GitHub account.