### PR TITLE
update the homebridge version to 1.2.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN case "$(uname -m)" in \
 
 ENV PATH="${PATH}:/homebridge/node_modules/.bin"
 
-ENV HOMEBRIDGE_VERSION=1.2.4
+ENV HOMEBRIDGE_VERSION=1.2.5
 RUN npm install -g --unsafe-perm homebridge@${HOMEBRIDGE_VERSION}
 
 ENV CONFIG_UI_VERSION=4.36.0 HOMEBRIDGE_CONFIG_UI=0 HOMEBRIDGE_CONFIG_UI_PORT=8080


### PR DESCRIPTION
the new homebridge version 1.2.5 was released - https://github.com/homebridge/homebridge/releases/tag/v1.2.5