### PR TITLE
node 14.17.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG S6_ARCH
-FROM oznu/s6-node:14.17.1-${S6_ARCH:-amd64}
+FROM oznu/s6-node:14.17.2-${S6_ARCH:-amd64}
 
 RUN apk add --no-cache git python2 python3 make g++ avahi-compat-libdns_sd avahi-dev dbus \
     iputils sudo nano \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,5 +1,5 @@
 ARG S6_ARCH
-FROM oznu/s6-node:14.17.1-ubuntu-${S6_ARCH:-amd64}
+FROM oznu/s6-node:14.17.2-ubuntu-${S6_ARCH:-amd64}
 
 RUN apt-get update \
   && apt-get install -y git python make g++ libnss-mdns avahi-discover libavahi-compat-libdnssd-dev \


### PR DESCRIPTION
updating the node version to 14.17.2, an accompanying PR has been made on docker-s6-alpine-node. i have tested this change on my machine and it runs for me at least, feel free to test it yourself too.