### PR TITLE
Upgrade to Homebridge 1.3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN case "$(uname -m)" in \
 
 ENV PATH="${PATH}:/homebridge/node_modules/.bin"
 
-ENV HOMEBRIDGE_VERSION=1.3.5
+ENV HOMEBRIDGE_VERSION=1.3.6
 RUN npm install -g --unsafe-perm homebridge@${HOMEBRIDGE_VERSION}
 
 ENV CONFIG_UI_VERSION=4.41.2 HOMEBRIDGE_CONFIG_UI=1 HOMEBRIDGE_CONFIG_UI_PORT=8581

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -23,7 +23,7 @@ RUN case "$(uname -m)" in \
 
 ENV PATH="${PATH}:/homebridge/node_modules/.bin"
 
-ENV HOMEBRIDGE_VERSION=1.3.5
+ENV HOMEBRIDGE_VERSION=1.3.6
 RUN npm install -g --unsafe-perm homebridge@${HOMEBRIDGE_VERSION}
 
 ENV CONFIG_UI_VERSION=4.41.2 HOMEBRIDGE_CONFIG_UI=1 HOMEBRIDGE_CONFIG_UI_PORT=8581


### PR DESCRIPTION
Bump homebridge to version 1.3.6

https://github.com/homebridge/homebridge/releases/tag/v1.3.6