### PR TITLE
Relocate homebridge.log to /homebridge/logs 

### DIFF
--- a/root/etc/logrotate.d/homebridge
+++ b/root/etc/logrotate.d/homebridge
@@ -1,6 +1,7 @@
-/homebridge/homebridge.log {
+/homebridge/logs/homebridge.log {
   size 10M
   copytruncate
   missingok
+  compress
   rotate 4
 }

--- a/root/etc/services.d/hb-service-logs/run
+++ b/root/etc/services.d/hb-service-logs/run
@@ -1,7 +1,8 @@
 #!/usr/bin/with-contenv sh
 
-[ -e /homebridge/homebridge.log ] || touch /homebridge/homebridge.log
+[ -e /homebridge/logs ] || mkdir -p /homebridge/logs
+[ -e /homebridge/logs/homebridge.log ] || touch /homebridge/logs/homebridge.log
 
-chown -R abc:abc /homebridge/homebridge.log
+chown -R abc:abc /homebridge/logs/homebridge.log
 
-exec s6-setuidgid abc tail -f --follow=name /homebridge/homebridge.log
+exec s6-setuidgid abc tail -f --follow=name /homebridge/logs/homebridge.log

--- a/root/etc/services.d/homebridge-config-ui-x/finish
+++ b/root/etc/services.d/homebridge-config-ui-x/finish
@@ -1,3 +1,3 @@
 #!/usr/bin/with-contenv sh
 
-/usr/bin/container-credits-banner >> /homebridge/homebridge.log
+/usr/bin/container-credits-banner >> /homebridge/logs/homebridge.log

--- a/root/etc/services.d/homebridge-config-ui-x/run
+++ b/root/etc/services.d/homebridge-config-ui-x/run
@@ -1,7 +1,8 @@
 #!/usr/bin/with-localenv sh
 
 # ensure log file exists
-touch /homebridge/homebridge.log
+[ -e /homebridge/logs ] || mkdir -p /homebridge/logs
+touch /homebridge/logs/homebridge.log
 
 # fix permissions
 chown -R abc:abc /homebridge

--- a/root/etc/services.d/homebridge/run
+++ b/root/etc/services.d/homebridge/run
@@ -27,4 +27,5 @@ fi
 
 echo $_HOMEBRIDGE_OPTS
 
-s6-setuidgid abc homebridge $_HOMEBRIDGE_OPTS 2>&1 | tee -a /homebridge/homebridge.log
+[ -e /homebridge/logs ] || mkdir -p /homebridge/logs
+s6-setuidgid abc homebridge $_HOMEBRIDGE_OPTS 2>&1 | tee -a /homebridge/logs/homebridge.log


### PR DESCRIPTION
Fixes #416 (and #350)
 
This PR relocates the `homebridge.log` to the `/homebridge/logs` sub directory. This allows for tmpfs volume mapping for the logs directory to reduce the IO related to logs on systems like RPIs