### PR TITLE
fixed noble BLE advertising

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ RUN npm install -g --unsafe-perm homebridge@${HOMEBRIDGE_VERSION}
 ENV CONFIG_UI_VERSION=4.42.0 HOMEBRIDGE_CONFIG_UI=1 HOMEBRIDGE_CONFIG_UI_PORT=8581
 RUN npm install -g --unsafe-perm homebridge-config-ui-x@${CONFIG_UI_VERSION}
 
+RUN setcap cap_net_raw+eip $(eval readlink -f `which node`)
+
 WORKDIR /homebridge
 VOLUME /homebridge
 


### PR DESCRIPTION
This commit fixes a problem when using plugins that depend on BLE/noble, see.

Using this command node is able to start/stop BLE advertising without running as root

see: https://github.com/noble/noble#running-without-rootsudo