### PR TITLE
Add amd64nvidia image for Nvidia HwAccel ffmpeg

### DIFF
--- a/Dockerfile.amd64nvidia
+++ b/Dockerfile.amd64nvidia
@@ -4,7 +4,7 @@ ARG NODE_VERSION=14.18.1
 FROM huyqt/docker-homebridge-ffmpeg:${FFMPEG_VERSION}-${ARCH} as ffmpeg
 
 ARG S6_ARCH
-FROM oznu/s6-node:16.13.2-ubuntu-${S6_ARCH:-amd64}
+FROM oznu/s6-node:16.14.0-ubuntu-${S6_ARCH:-amd64}
 
 COPY --from=ffmpeg /usr/local /usr/local/
 

--- a/Dockerfile.amd64nvidia
+++ b/Dockerfile.amd64nvidia
@@ -1,0 +1,77 @@
+ARG ARCH=amd64nvidia
+ARG FFMPEG_VERSION=1.2.0
+ARG NODE_VERSION=14.18.1
+FROM huyqt/docker-homebridge-ffmpeg:${FFMPEG_VERSION}-${ARCH} as ffmpeg
+
+ARG S6_ARCH
+FROM oznu/s6-node:16.13.2-ubuntu-${S6_ARCH:-amd64}
+
+COPY --from=ffmpeg /usr/local /usr/local/
+
+RUN apt-get update \
+  && apt-get install -y git python make g++ libnss-mdns avahi-discover libavahi-compat-libdnssd-dev \
+    net-tools iproute2 sudo nano \
+  && apt-get clean \
+  && rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/* \
+  && chmod 4755 /bin/ping \
+  && mkdir /homebridge \
+  && npm set global-style=true \
+  && npm set audit=false \ 
+  && npm set fund=false
+
+# Install packages for apt repo
+RUN apt-get -qq update \
+    && apt-get -qq install --no-install-recommends -y \
+    # ffmpeg dependencies
+    libgomp1 \
+    && rm -rf /var/lib/apt/lists/* \
+    && (apt-get autoremove -y; apt-get autoclean -y)
+
+
+# nvidia layer (see https://gitlab.com/nvidia/container-images/cuda/blob/master/dist/11.1/ubuntu18.04-x86_64/base/Dockerfile)
+ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gnupg2 curl ca-certificates && \
+    curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub | apt-key add - && \
+    echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64 /" > /etc/apt/sources.list.d/cuda.list && \
+    echo "deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64 /" > /etc/apt/sources.list.d/nvidia-ml.list && \
+    (apt-get autoremove -y; apt-get autoclean -y) \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV CUDA_VERSION 11.1.1
+
+# For libraries in the cuda-compat-* package: https://docs.nvidia.com/cuda/eula/index.html#attachment-a
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    cuda-cudart-11-1=11.1.74-1 \
+    cuda-compat-11-1 \
+    && ln -s cuda-11.1 /usr/local/cuda && \
+    rm -rf /var/lib/apt/lists/*
+
+# Required for nvidia-docker v1
+RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf && \
+    echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
+
+ENV PATH ${PATH}:/usr/local/nvidia/bin:/usr/local/cuda/bin
+ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
+
+# nvidia-container-runtime
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility,video
+ENV NVIDIA_REQUIRE_CUDA "cuda>=11.1 brand=tesla,driver>=418,driver<419 brand=tesla,driver>=440,driver<441 brand=tesla,driver>=450,driver<451"
+
+ENV PATH="${PATH}:/homebridge/node_modules/.bin"
+
+ENV HOMEBRIDGE_VERSION=1.4.0
+RUN npm install -g --unsafe-perm homebridge@${HOMEBRIDGE_VERSION}
+
+ENV CONFIG_UI_VERSION=4.42.0 HOMEBRIDGE_CONFIG_UI=1 HOMEBRIDGE_CONFIG_UI_PORT=8581
+RUN npm install -g --unsafe-perm homebridge-config-ui-x@${CONFIG_UI_VERSION}
+
+WORKDIR /homebridge
+VOLUME /homebridge
+
+COPY root /
+
+ARG AVAHI
+ENV ENABLE_AVAHI="${AVAHI:-1}"

--- a/Dockerfile.amd64nvidia
+++ b/Dockerfile.amd64nvidia
@@ -1,5 +1,5 @@
 ARG ARCH=amd64nvidia
-ARG FFMPEG_VERSION=1.2.0
+ARG FFMPEG_VERSION=1.3.0
 ARG NODE_VERSION=14.18.1
 FROM huyqt/docker-homebridge-ffmpeg:${FFMPEG_VERSION}-${ARCH} as ffmpeg
 

--- a/Dockerfile.ffmpeg.amd64nvidia
+++ b/Dockerfile.ffmpeg.amd64nvidia
@@ -52,6 +52,7 @@ ENV     FFMPEG_VERSION=4.3.2 \
         OGG_VERSION=1.3.2 \
         OPENCOREAMR_VERSION=0.1.5 \
         OPUS_VERSION=1.2 \
+        SPEEX_VERSION=1.2rc1 \
         OPENJPEG_VERSION=2.1.2 \
         THEORA_VERSION=1.1.1 \
         VORBIS_VERSION=1.3.5 \
@@ -178,6 +179,18 @@ RUN \
         ./configure --prefix="${PREFIX}" --enable-shared && \
         make && \
         make install && \
+        rm -rf ${DIR}
+## libspeex http://speex.org/
+RUN \
+        dir=/tmp/speex && \
+        mkdir -p ${DIR} && \
+        cd ${DIR} && \
+        curl -s http://downloads.xiph.org/releases/speex/speex-${SPEEX_VERSION}.tar.gz | \
+        tar -zx - -C . && \
+        ./configure --prefix="${SRC}" --disable-shared --datadir="${DIR}" --disable-dependency-tracking && \
+        make && \
+        make install && \
+        make distclean && \
         rm -rf ${DIR}
 ### libvorbis https://xiph.org/vorbis/
 RUN \
@@ -481,6 +494,7 @@ RUN \
         --enable-libvidstab \
         --enable-libmp3lame \
         --enable-libopus \
+        --enable-libspeex \
         --enable-libtheora \
         --enable-libvorbis \
         --enable-libvpx \
@@ -548,3 +562,4 @@ COPY --from=build /usr/local/include /usr/local/include/
 
 # Let's make sure the app built correctly
 # Convenient to verify on https://hub.docker.com/r/jrottenberg/ffmpeg/builds/ console output
+

--- a/Dockerfile.ffmpeg.amd64nvidia
+++ b/Dockerfile.ffmpeg.amd64nvidia
@@ -1,0 +1,550 @@
+# copied from frigate-ffmpeg, modified for ubuntu 18.04 base
+# inspired by https://github.com/jrottenberg/ffmpeg/blob/master/docker-images/4.3/ubuntu1804/Dockerfile
+
+# ffmpeg - http://ffmpeg.org/download.html
+#
+# From https://trac.ffmpeg.org/wiki/CompilationGuide/Ubuntu
+#
+# https://hub.docker.com/r/jrottenberg/ffmpeg/
+#
+#
+
+FROM    nvidia/cuda:11.1-devel-ubuntu18.04 AS devel-base
+
+ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
+ENV         DEBIAN_FRONTEND=noninteractive
+
+WORKDIR     /tmp/workdir
+
+RUN     apt-get -yqq update && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 && \
+        apt-get autoremove -y && \
+        apt-get clean -y
+
+FROM       nvidia/cuda:11.1-runtime-ubuntu18.04 AS runtime-base
+
+ENV	    NVIDIA_DRIVER_CAPABILITIES compute,utility,video
+ENV         DEBIAN_FRONTEND=noninteractive
+
+WORKDIR     /tmp/workdir
+
+RUN     apt-get -yqq update && \
+        apt-get install -yq --no-install-recommends ca-certificates expat libgomp1 libxcb-shape0-dev && \
+        apt-get autoremove -y && \
+        apt-get clean -y
+
+
+FROM  devel-base as build
+
+ENV        NVIDIA_HEADERS_VERSION=9.1.23.1
+
+ENV     FFMPEG_VERSION=4.3.2 \
+        AOM_VERSION=v1.0.0 \
+        FDKAAC_VERSION=0.1.5 \
+        FREETYPE_VERSION=2.10.4 \
+        FRIBIDI_VERSION=0.19.7 \
+        KVAZAAR_VERSION=1.2.0 \
+        LAME_VERSION=3.100 \
+        LIBPTHREAD_STUBS_VERSION=0.4 \
+        LIBVIDSTAB_VERSION=1.1.0 \
+        LIBXCB_VERSION=1.13.1 \
+        XCBPROTO_VERSION=1.13 \
+        OGG_VERSION=1.3.2 \
+        OPENCOREAMR_VERSION=0.1.5 \
+        OPUS_VERSION=1.2 \
+        OPENJPEG_VERSION=2.1.2 \
+        THEORA_VERSION=1.1.1 \
+        VORBIS_VERSION=1.3.5 \
+        VPX_VERSION=1.8.0 \
+        WEBP_VERSION=1.0.2 \
+        X264_VERSION=20170226-2245-stable \
+        X265_VERSION=3.1.1 \
+        XAU_VERSION=1.0.9 \
+        XORG_MACROS_VERSION=1.19.2 \
+        XPROTO_VERSION=7.0.31 \
+        XVID_VERSION=1.3.4 \
+        LIBZMQ_VERSION=4.3.2 \
+        LIBSRT_VERSION=1.4.1 \
+        LIBARIBB24_VERSION=1.0.3 \
+        LIBPNG_VERSION=1.6.9 \
+        SRC=/usr/local
+
+ARG         FREETYPE_SHA256SUM="5eab795ebb23ac77001cfb68b7d4d50b5d6c7469247b0b01b2c953269f658dac freetype-2.10.4.tar.gz"
+ARG         FRIBIDI_SHA256SUM="3fc96fa9473bd31dcb5500bdf1aa78b337ba13eb8c301e7c28923fea982453a8 0.19.7.tar.gz"
+ARG         LIBVIDSTAB_SHA256SUM="14d2a053e56edad4f397be0cb3ef8eb1ec3150404ce99a426c4eb641861dc0bb v1.1.0.tar.gz"
+ARG         OGG_SHA256SUM="e19ee34711d7af328cb26287f4137e70630e7261b17cbe3cd41011d73a654692 libogg-1.3.2.tar.gz"
+ARG         OPUS_SHA256SUM="77db45a87b51578fbc49555ef1b10926179861d854eb2613207dc79d9ec0a9a9 opus-1.2.tar.gz"
+ARG         THEORA_SHA256SUM="40952956c47811928d1e7922cda3bc1f427eb75680c3c37249c91e949054916b libtheora-1.1.1.tar.gz"
+ARG         VORBIS_SHA256SUM="6efbcecdd3e5dfbf090341b485da9d176eb250d893e3eb378c428a2db38301ce libvorbis-1.3.5.tar.gz"
+ARG         XVID_SHA256SUM="4e9fd62728885855bc5007fe1be58df42e5e274497591fec37249e1052ae316f xvidcore-1.3.4.tar.gz"
+ARG         LIBZMQ_SHA256SUM="02ecc88466ae38cf2c8d79f09cfd2675ba299a439680b64ade733e26a349edeb v4.3.2.tar.gz"
+ARG         LIBARIBB24_SHA256SUM="f61560738926e57f9173510389634d8c06cabedfa857db4b28fb7704707ff128 v1.0.3.tar.gz"
+
+
+ARG         LD_LIBRARY_PATH=/opt/ffmpeg/lib
+ARG         MAKEFLAGS="-j2"
+ARG         PKG_CONFIG_PATH="/opt/ffmpeg/share/pkgconfig:/opt/ffmpeg/lib/pkgconfig:/opt/ffmpeg/lib64/pkgconfig"
+ARG         PREFIX=/opt/ffmpeg
+ARG         LD_LIBRARY_PATH="/opt/ffmpeg/lib:/opt/ffmpeg/lib64"
+
+
+RUN     buildDeps="autoconf \
+        automake \
+        cmake \
+        curl \
+        bzip2 \
+        libexpat1-dev \
+        g++ \
+        gcc \
+        git \
+        gperf \
+        libtool \
+        make \
+        nasm \
+        perl \
+        pkg-config \
+        python \
+        libssl-dev \
+        yasm \
+        zlib1g-dev" && \
+        apt-get -yqq update && \
+        apt-get install -yq --no-install-recommends ${buildDeps}
+
+RUN \
+        DIR=/tmp/nv-codec-headers && \
+        git clone https://github.com/FFmpeg/nv-codec-headers ${DIR} && \
+        cd ${DIR} && \
+        git checkout n${NVIDIA_HEADERS_VERSION} && \
+        make PREFIX="${PREFIX}" && \
+        make install PREFIX="${PREFIX}" && \
+        rm -rf ${DIR}
+
+## opencore-amr https://sourceforge.net/projects/opencore-amr/
+RUN \
+        DIR=/tmp/opencore-amr && \
+        mkdir -p ${DIR} && \
+        cd ${DIR} && \
+        curl -sL https://versaweb.dl.sourceforge.net/project/opencore-amr/opencore-amr/opencore-amr-${OPENCOREAMR_VERSION}.tar.gz | \
+        tar -zx --strip-components=1 && \
+        ./configure --prefix="${PREFIX}" --enable-shared  && \
+        make && \
+        make install && \
+        rm -rf ${DIR}
+## x264 http://www.videolan.org/developers/x264.html
+RUN \
+        DIR=/tmp/x264 && \
+        mkdir -p ${DIR} && \
+        cd ${DIR} && \
+        curl -sL https://download.videolan.org/pub/videolan/x264/snapshots/x264-snapshot-${X264_VERSION}.tar.bz2 | \
+        tar -jx --strip-components=1 && \
+        ./configure --prefix="${PREFIX}" --enable-shared --enable-pic --disable-cli && \
+        make && \
+        make install && \
+        rm -rf ${DIR}
+### x265 http://x265.org/
+RUN \
+        DIR=/tmp/x265 && \
+        mkdir -p ${DIR} && \
+        cd ${DIR} && \
+        curl -sL https://download.videolan.org/pub/videolan/x265/x265_${X265_VERSION}.tar.gz  | \
+        tar -zx && \
+        cd x265_${X265_VERSION}/build/linux && \
+        sed -i "/-DEXTRA_LIB/ s/$/ -DCMAKE_INSTALL_PREFIX=\${PREFIX}/" multilib.sh && \
+        sed -i "/^cmake/ s/$/ -DENABLE_CLI=OFF/" multilib.sh && \
+        ./multilib.sh && \
+        make -C 8bit install && \
+        rm -rf ${DIR}
+### libogg https://www.xiph.org/ogg/
+RUN \
+        DIR=/tmp/ogg && \
+        mkdir -p ${DIR} && \
+        cd ${DIR} && \
+        curl -sLO http://downloads.xiph.org/releases/ogg/libogg-${OGG_VERSION}.tar.gz && \
+        echo ${OGG_SHA256SUM} | sha256sum --check && \
+        tar -zx --strip-components=1 -f libogg-${OGG_VERSION}.tar.gz && \
+        ./configure --prefix="${PREFIX}" --enable-shared  && \
+        make && \
+        make install && \
+        rm -rf ${DIR}
+### libopus https://www.opus-codec.org/
+RUN \
+        DIR=/tmp/opus && \
+        mkdir -p ${DIR} && \
+        cd ${DIR} && \
+        curl -sLO https://archive.mozilla.org/pub/opus/opus-${OPUS_VERSION}.tar.gz && \
+        echo ${OPUS_SHA256SUM} | sha256sum --check && \
+        tar -zx --strip-components=1 -f opus-${OPUS_VERSION}.tar.gz && \
+        autoreconf -fiv && \
+        ./configure --prefix="${PREFIX}" --enable-shared && \
+        make && \
+        make install && \
+        rm -rf ${DIR}
+### libvorbis https://xiph.org/vorbis/
+RUN \
+        DIR=/tmp/vorbis && \
+        mkdir -p ${DIR} && \
+        cd ${DIR} && \
+        curl -sLO http://downloads.xiph.org/releases/vorbis/libvorbis-${VORBIS_VERSION}.tar.gz && \
+        echo ${VORBIS_SHA256SUM} | sha256sum --check && \
+        tar -zx --strip-components=1 -f libvorbis-${VORBIS_VERSION}.tar.gz && \
+        ./configure --prefix="${PREFIX}" --with-ogg="${PREFIX}" --enable-shared && \
+        make && \
+        make install && \
+        rm -rf ${DIR}
+### libtheora http://www.theora.org/
+RUN \
+        DIR=/tmp/theora && \
+        mkdir -p ${DIR} && \
+        cd ${DIR} && \
+        curl -sLO http://downloads.xiph.org/releases/theora/libtheora-${THEORA_VERSION}.tar.gz && \
+        echo ${THEORA_SHA256SUM} | sha256sum --check && \
+        tar -zx --strip-components=1 -f libtheora-${THEORA_VERSION}.tar.gz && \
+        ./configure --prefix="${PREFIX}" --with-ogg="${PREFIX}" --enable-shared && \
+        make && \
+        make install && \
+        rm -rf ${DIR}
+### libvpx https://www.webmproject.org/code/
+RUN \
+        DIR=/tmp/vpx && \
+        mkdir -p ${DIR} && \
+        cd ${DIR} && \
+        curl -sL https://codeload.github.com/webmproject/libvpx/tar.gz/v${VPX_VERSION} | \
+        tar -zx --strip-components=1 && \
+        ./configure --prefix="${PREFIX}" --enable-vp8 --enable-vp9 --enable-vp9-highbitdepth --enable-pic --enable-shared \
+        --disable-debug --disable-examples --disable-docs --disable-install-bins  && \
+        make && \
+        make install && \
+        rm -rf ${DIR}
+### libwebp https://developers.google.com/speed/webp/
+RUN \
+        DIR=/tmp/vebp && \
+        mkdir -p ${DIR} && \
+        cd ${DIR} && \
+        curl -sL https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-${WEBP_VERSION}.tar.gz | \
+        tar -zx --strip-components=1 && \
+        ./configure --prefix="${PREFIX}" --enable-shared  && \
+        make && \
+        make install && \
+        rm -rf ${DIR}
+### libmp3lame http://lame.sourceforge.net/
+RUN \
+        DIR=/tmp/lame && \
+        mkdir -p ${DIR} && \
+        cd ${DIR} && \
+        curl -sL https://versaweb.dl.sourceforge.net/project/lame/lame/$(echo ${LAME_VERSION} | sed -e 's/[^0-9]*\([0-9]*\)[.]\([0-9]*\)[.]\([0-9]*\)\([0-9A-Za-z-]*\)/\1.\2/')/lame-${LAME_VERSION}.tar.gz | \
+        tar -zx --strip-components=1 && \
+        ./configure --prefix="${PREFIX}" --bindir="${PREFIX}/bin" --enable-shared --enable-nasm --disable-frontend && \
+        make && \
+        make install && \
+        rm -rf ${DIR}
+### xvid https://www.xvid.com/
+RUN \
+        DIR=/tmp/xvid && \
+        mkdir -p ${DIR} && \
+        cd ${DIR} && \
+        curl -sLO http://downloads.xvid.org/downloads/xvidcore-${XVID_VERSION}.tar.gz && \
+        echo ${XVID_SHA256SUM} | sha256sum --check && \
+        tar -zx -f xvidcore-${XVID_VERSION}.tar.gz && \
+        cd xvidcore/build/generic && \
+        ./configure --prefix="${PREFIX}" --bindir="${PREFIX}/bin" && \
+        make && \
+        make install && \
+        rm -rf ${DIR}
+### fdk-aac https://github.com/mstorsjo/fdk-aac
+RUN \
+        DIR=/tmp/fdk-aac && \
+        mkdir -p ${DIR} && \
+        cd ${DIR} && \
+        curl -sL https://github.com/mstorsjo/fdk-aac/archive/v${FDKAAC_VERSION}.tar.gz | \
+        tar -zx --strip-components=1 && \
+        autoreconf -fiv && \
+        ./configure --prefix="${PREFIX}" --enable-shared --datadir="${DIR}" && \
+        make && \
+        make install && \
+        rm -rf ${DIR}
+## openjpeg https://github.com/uclouvain/openjpeg
+RUN \
+        DIR=/tmp/openjpeg && \
+        mkdir -p ${DIR} && \
+        cd ${DIR} && \
+        curl -sL https://github.com/uclouvain/openjpeg/archive/v${OPENJPEG_VERSION}.tar.gz | \
+        tar -zx --strip-components=1 && \
+        cmake -DBUILD_THIRDPARTY:BOOL=ON -DCMAKE_INSTALL_PREFIX="${PREFIX}" . && \
+        make && \
+        make install && \
+        rm -rf ${DIR}
+## freetype https://www.freetype.org/
+RUN  \
+        DIR=/tmp/freetype && \
+        mkdir -p ${DIR} && \
+        cd ${DIR} && \
+        curl -sLO https://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.gz && \
+        echo ${FREETYPE_SHA256SUM} | sha256sum --check && \
+        tar -zx --strip-components=1 -f freetype-${FREETYPE_VERSION}.tar.gz && \
+        ./configure --prefix="${PREFIX}" --disable-static --enable-shared && \
+        make && \
+        make install && \
+        rm -rf ${DIR}
+## libvstab https://github.com/georgmartius/vid.stab
+RUN  \
+        DIR=/tmp/vid.stab && \
+        mkdir -p ${DIR} && \
+        cd ${DIR} && \
+        curl -sLO https://github.com/georgmartius/vid.stab/archive/v${LIBVIDSTAB_VERSION}.tar.gz && \
+        echo ${LIBVIDSTAB_SHA256SUM} | sha256sum --check &&  \
+        tar -zx --strip-components=1 -f v${LIBVIDSTAB_VERSION}.tar.gz && \
+        cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" . && \
+        make && \
+        make install && \
+        rm -rf ${DIR}
+## fridibi https://www.fribidi.org/
+RUN  \
+        DIR=/tmp/fribidi && \
+        mkdir -p ${DIR} && \
+        cd ${DIR} && \
+        curl -sLO https://github.com/fribidi/fribidi/archive/${FRIBIDI_VERSION}.tar.gz && \
+        echo ${FRIBIDI_SHA256SUM} | sha256sum --check && \
+        tar -zx --strip-components=1 -f ${FRIBIDI_VERSION}.tar.gz && \
+        sed -i 's/^SUBDIRS =.*/SUBDIRS=gen.tab charset lib bin/' Makefile.am && \
+        ./bootstrap --no-config --auto && \
+        ./configure --prefix="${PREFIX}" --disable-static --enable-shared && \
+        make -j1 && \
+        make install && \
+        rm -rf ${DIR}
+## kvazaar https://github.com/ultravideo/kvazaar
+RUN \
+        DIR=/tmp/kvazaar && \
+        mkdir -p ${DIR} && \
+        cd ${DIR} && \
+        curl -sLO https://github.com/ultravideo/kvazaar/archive/v${KVAZAAR_VERSION}.tar.gz && \
+        tar -zx --strip-components=1 -f v${KVAZAAR_VERSION}.tar.gz && \
+        ./autogen.sh && \
+        ./configure --prefix="${PREFIX}" --disable-static --enable-shared && \
+        make && \
+        make install && \
+        rm -rf ${DIR}
+
+RUN \
+        DIR=/tmp/aom && \
+        git clone --branch ${AOM_VERSION} --depth 1 https://aomedia.googlesource.com/aom ${DIR} ; \
+        cd ${DIR} ; \
+        rm -rf CMakeCache.txt CMakeFiles ; \
+        mkdir -p ./aom_build ; \
+        cd ./aom_build ; \
+        cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DBUILD_SHARED_LIBS=1 ..; \
+        make ; \
+        make install ; \
+        rm -rf ${DIR}
+
+## libxcb (and supporting libraries) for screen capture https://xcb.freedesktop.org/
+RUN \
+        DIR=/tmp/xorg-macros && \
+        mkdir -p ${DIR} && \
+        cd ${DIR} && \
+        curl -sLO https://www.x.org/archive//individual/util/util-macros-${XORG_MACROS_VERSION}.tar.gz && \
+        tar -zx --strip-components=1 -f util-macros-${XORG_MACROS_VERSION}.tar.gz && \
+        ./configure --srcdir=${DIR} --prefix="${PREFIX}" && \
+        make && \
+        make install && \
+        rm -rf ${DIR}
+
+RUN \
+        DIR=/tmp/xproto && \
+        mkdir -p ${DIR} && \
+        cd ${DIR} && \
+        curl -sLO https://www.x.org/archive/individual/proto/xproto-${XPROTO_VERSION}.tar.gz && \
+        tar -zx --strip-components=1 -f xproto-${XPROTO_VERSION}.tar.gz && \
+        ./configure --srcdir=${DIR} --prefix="${PREFIX}" && \
+        make && \
+        make install && \
+        rm -rf ${DIR}
+
+RUN \
+        DIR=/tmp/libXau && \
+        mkdir -p ${DIR} && \
+        cd ${DIR} && \
+        curl -sLO https://www.x.org/archive/individual/lib/libXau-${XAU_VERSION}.tar.gz && \
+        tar -zx --strip-components=1 -f libXau-${XAU_VERSION}.tar.gz && \
+        ./configure --srcdir=${DIR} --prefix="${PREFIX}" && \
+        make && \
+        make install && \
+        rm -rf ${DIR}
+
+RUN \
+        DIR=/tmp/libpthread-stubs && \
+        mkdir -p ${DIR} && \
+        cd ${DIR} && \
+        curl -sLO https://xcb.freedesktop.org/dist/libpthread-stubs-${LIBPTHREAD_STUBS_VERSION}.tar.gz && \
+        tar -zx --strip-components=1 -f libpthread-stubs-${LIBPTHREAD_STUBS_VERSION}.tar.gz && \
+        ./configure --prefix="${PREFIX}" && \
+        make && \
+        make install && \
+        rm -rf ${DIR}
+
+RUN \
+        DIR=/tmp/libxcb-proto && \
+        mkdir -p ${DIR} && \
+        cd ${DIR} && \
+        curl -sLO https://xcb.freedesktop.org/dist/xcb-proto-${XCBPROTO_VERSION}.tar.gz && \
+        tar -zx --strip-components=1 -f xcb-proto-${XCBPROTO_VERSION}.tar.gz && \
+        ACLOCAL_PATH="${PREFIX}/share/aclocal" ./autogen.sh && \
+        ./configure --prefix="${PREFIX}" && \
+        make && \
+        make install && \
+        rm -rf ${DIR}
+
+RUN \
+        DIR=/tmp/libxcb && \
+        mkdir -p ${DIR} && \
+        cd ${DIR} && \
+        curl -sLO https://xcb.freedesktop.org/dist/libxcb-${LIBXCB_VERSION}.tar.gz && \
+        tar -zx --strip-components=1 -f libxcb-${LIBXCB_VERSION}.tar.gz && \
+        ACLOCAL_PATH="${PREFIX}/share/aclocal" ./autogen.sh && \
+        ./configure --prefix="${PREFIX}" --disable-static --enable-shared && \
+        make && \
+        make install && \
+        rm -rf ${DIR}
+
+## libzmq https://github.com/zeromq/libzmq/
+RUN \
+        DIR=/tmp/libzmq && \
+        mkdir -p ${DIR} && \
+        cd ${DIR} && \
+        curl -sLO https://github.com/zeromq/libzmq/archive/v${LIBZMQ_VERSION}.tar.gz && \
+        echo ${LIBZMQ_SHA256SUM} | sha256sum --check && \
+        tar -xz --strip-components=1 -f v${LIBZMQ_VERSION}.tar.gz && \
+        ./autogen.sh && \
+        ./configure --prefix="${PREFIX}" && \
+        make && \
+        make check && \
+        make install && \
+        rm -rf ${DIR}
+
+## libsrt https://github.com/Haivision/srt
+RUN \
+        DIR=/tmp/srt && \
+        mkdir -p ${DIR} && \
+        cd ${DIR} && \
+        curl -sLO https://github.com/Haivision/srt/archive/v${LIBSRT_VERSION}.tar.gz && \
+        tar -xz --strip-components=1 -f v${LIBSRT_VERSION}.tar.gz && \
+        cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" . && \
+        make && \
+        make install && \
+        rm -rf ${DIR}
+
+## libpng
+RUN \
+        DIR=/tmp/png && \
+        mkdir -p ${DIR} && \
+        cd ${DIR} && \
+        git clone https://git.code.sf.net/p/libpng/code ${DIR} -b v${LIBPNG_VERSION} --depth 1 && \
+        ./autogen.sh && \
+        ./configure --prefix="${PREFIX}" && \
+        make check && \
+        make install && \
+        rm -rf ${DIR}
+
+## libaribb24
+RUN \
+        DIR=/tmp/b24 && \
+        mkdir -p ${DIR} && \
+        cd ${DIR} && \
+        curl -sLO https://github.com/nkoriyama/aribb24/archive/v${LIBARIBB24_VERSION}.tar.gz && \
+        echo ${LIBARIBB24_SHA256SUM} | sha256sum --check && \
+        tar -xz --strip-components=1 -f v${LIBARIBB24_VERSION}.tar.gz && \
+        autoreconf -fiv && \
+        ./configure CFLAGS="-I${PREFIX}/include -fPIC" --prefix="${PREFIX}" && \
+        make && \
+        make install && \
+        rm -rf ${DIR}
+
+## ffmpeg https://ffmpeg.org/
+RUN  \
+        DIR=/tmp/ffmpeg && mkdir -p ${DIR} && cd ${DIR} && \
+        curl -sLO https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.bz2 && \
+        tar -jx --strip-components=1 -f ffmpeg-${FFMPEG_VERSION}.tar.bz2
+
+
+
+RUN \
+        DIR=/tmp/ffmpeg && mkdir -p ${DIR} && cd ${DIR} && \
+        ./configure \
+        --disable-debug \
+        --disable-doc \
+        --disable-ffplay \
+        --enable-shared \
+        --enable-avresample \
+        --enable-libopencore-amrnb \
+        --enable-libopencore-amrwb \
+        --enable-gpl \
+        --enable-libfreetype \
+        --enable-libvidstab \
+        --enable-libmp3lame \
+        --enable-libopus \
+        --enable-libtheora \
+        --enable-libvorbis \
+        --enable-libvpx \
+        --enable-libwebp \
+        --enable-libxcb \
+        --enable-libx265 \
+        --enable-libxvid \
+        --enable-libx264 \
+        --enable-nonfree \
+        --enable-openssl \
+        --enable-libfdk_aac \
+        --enable-postproc \
+        --enable-small \
+        --enable-version3 \
+        --enable-libzmq \
+        --extra-libs=-ldl \
+        --prefix="${PREFIX}" \
+        --enable-libopenjpeg \
+        --enable-libkvazaar \
+        --enable-libaom \
+        --extra-libs=-lpthread \
+        --enable-libsrt \
+        --enable-libaribb24 \
+        --enable-nvenc \
+        --enable-cuda \
+        --enable-cuvid \
+        --enable-libnpp \
+        --extra-cflags="-I${PREFIX}/include -I${PREFIX}/include/ffnvcodec -I/usr/local/cuda/include/" \
+        --extra-ldflags="-L${PREFIX}/lib -L/usr/local/cuda/lib64 -L/usr/local/cuda/lib32/" && \
+        make && \
+        make install && \
+        make tools/zmqsend && cp tools/zmqsend ${PREFIX}/bin/ && \
+        make distclean && \
+        hash -r && \
+        cd tools && \
+        make qt-faststart && cp qt-faststart ${PREFIX}/bin/
+
+## cleanup
+RUN \
+        LD_LIBRARY_PATH="${PREFIX}/lib:${PREFIX}/lib64:${LD_LIBRARY_PATH}" ldd ${PREFIX}/bin/ffmpeg | grep opt/ffmpeg | cut -d ' ' -f 3 | xargs -i cp {} /usr/local/lib/ && \
+        for lib in /usr/local/lib/*.so.*; do ln -s "${lib##*/}" "${lib%%.so.*}".so; done && \
+        cp ${PREFIX}/bin/* /usr/local/bin/ && \
+        cp -r ${PREFIX}/share/* /usr/local/share/ && \
+        LD_LIBRARY_PATH=/usr/local/lib ffmpeg -buildconf && \
+        cp -r ${PREFIX}/include/libav* ${PREFIX}/include/libpostproc ${PREFIX}/include/libsw* /usr/local/include && \
+        mkdir -p /usr/local/lib/pkgconfig && \
+        for pc in ${PREFIX}/lib/pkgconfig/libav*.pc ${PREFIX}/lib/pkgconfig/libpostproc.pc ${PREFIX}/lib/pkgconfig/libsw*.pc; do \
+        sed "s:${PREFIX}:/usr/local:g; s:/lib64:/lib:g" <"$pc" >/usr/local/lib/pkgconfig/"${pc##*/}"; \
+        done
+
+
+
+FROM        runtime-base AS release
+
+ENV         LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
+
+CMD         ["--help"]
+ENTRYPOINT  ["ffmpeg"]
+
+# copy only needed files, without copying nvidia dev files
+COPY --from=build /usr/local/bin /usr/local/bin/
+COPY --from=build /usr/local/share /usr/local/share/
+COPY --from=build /usr/local/lib /usr/local/lib/
+COPY --from=build /usr/local/include /usr/local/include/
+
+# Let's make sure the app built correctly
+# Convenient to verify on https://hub.docker.com/r/jrottenberg/ffmpeg/builds/ console output

--- a/Dockerfile.ffmpeg.amd64nvidia
+++ b/Dockerfile.ffmpeg.amd64nvidia
@@ -52,7 +52,7 @@ ENV     FFMPEG_VERSION=4.3.2 \
         OGG_VERSION=1.3.2 \
         OPENCOREAMR_VERSION=0.1.5 \
         OPUS_VERSION=1.2 \
-        SPEEX_VERSION=1.2rc1 \
+        SPEEX_VERSION=1.2.0 \
         OPENJPEG_VERSION=2.1.2 \
         THEORA_VERSION=1.1.1 \
         VORBIS_VERSION=1.3.5 \
@@ -185,8 +185,8 @@ RUN \
         DIR=/tmp/speex && \
         mkdir -p ${DIR} && \
         cd ${DIR} && \
-        curl -sLO http://downloads.us.xiph.org/releases/speex/speex-1.2.0.tar.gz && \
-        tar -zx --strip-components=1 -f speex-1.2.0.tar.gz && \
+        curl -sLO http://downloads.us.xiph.org/releases/speex/speex-${SPEEX_VERSION}.tar.gz && \
+        tar -zx --strip-components=1 -f speex-${SPEEX_VERSION}.tar.gz && \
         ./configure --prefix="${PREFIX}" --enable-shared --disable-static --datadir="${DIR}" && \
         make && \
         make install && \

--- a/Dockerfile.ffmpeg.amd64nvidia
+++ b/Dockerfile.ffmpeg.amd64nvidia
@@ -182,12 +182,12 @@ RUN \
         rm -rf ${DIR}
 ## libspeex http://speex.org/
 RUN \
-        dir=/tmp/speex && \
+        DIR=/tmp/speex && \
         mkdir -p ${DIR} && \
         cd ${DIR} && \
-        curl -s http://downloads.xiph.org/releases/speex/speex-${SPEEX_VERSION}.tar.gz | \
-        tar -zx - -C . && \
-        ./configure --prefix="${SRC}" --disable-shared --datadir="${DIR}" --disable-dependency-tracking && \
+        curl -sLO http://downloads.us.xiph.org/releases/speex/speex-1.2.0.tar.gz && \
+        tar -zx --strip-components=1 -f speex-1.2.0.tar.gz && \
+        ./configure --prefix="${PREFIX}" --enable-shared --disable-static --datadir="${DIR}" && \
         make && \
         make install && \
         make distclean && \

--- a/homebridge-amd64nvidia.xml
+++ b/homebridge-amd64nvidia.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Containers>
+  <TemplateURL>https://raw.githubusercontent.com/huyqt/docker-homebridge/master/homebridge.xml</TemplateURL>
+  <Beta>False</Beta>
+  <Category>HomeAutomation Tools</Category>
+  <Name>homebridge</Name>
+  <Description>
+    [b][span style='color: #3d1a63;']Description[/span][/b][br]
+    Homebridge allows you to integrate with smart home devices that do not natively support HomeKit. There are over 2,000 Homebridge plugins supporting thousands of different smart accessories.[br][br]
+    [b][span style='color: #3d1a63;']Configuration[/span][/b][br]
+    [b]/homebridge[/b] This is where Homebridge will store it's configuration files, plugins and logs.[br]
+    [b][span style='color: #3d1a63;']Documentation[/span][/b][br]
+    https://github.com/homebridge/homebridge/wiki[br]
+  </Description>
+  <Overview>
+    Homebridge allows you to integrate with smart home devices that do not natively support HomeKit. There are over 2,000 Homebridge plugins supporting thousands of different smart accessories.
+  </Overview>
+  <Support>https://discord.gg/Cmq8a44</Support>
+  <Registry>https://registry.hub.docker.com/r/huyqt/homebridge/</Registry>
+  <GitHub>https://github.com/huyqt/docker-homebridge</GitHub>
+  <Repository>huyqt/homebridge:amd64nvidia</Repository>
+  <Project>https://homebridge.io</Project>
+  <BindTime>true</BindTime>
+  <Privileged>false</Privileged>
+  <Networking>
+    <Mode>host</Mode>
+  </Networking>
+  <Environment>
+    <Variable>
+      <Name>HOMEBRIDGE_CONFIG_UI</Name>
+      <Value>1</Value>
+    </Variable>
+    <Variable>
+      <Name>HOMEBRIDGE_CONFIG_UI_PORT</Name>
+      <Value>8581</Value>
+    </Variable>
+    <Variable>
+      <Name>PUID</Name>
+      <Value>99</Value>
+    </Variable>
+    <Variable>
+      <Name>PGID</Name>
+      <Value>100</Value>
+    </Variable>
+    <Variable>
+      <Name>NVIDIA_VISIBLE_DEVICES</Name>
+      <Value></Value>
+    </Variable>
+    <Variable>
+      <Name>NVIDIA_DRIVER_CAPABILITIES</Name>
+      <Value>compute,utility,video</Value>
+    </Variable>
+  </Environment>
+  <Data>
+    <Volume>
+      <HostDir>/mnt/user/appdata/homebridge</HostDir>
+      <ContainerDir>/homebridge</ContainerDir>
+      <Mode>rw</Mode>
+    </Volume>
+  </Data>
+  <Shell>bash</Shell>
+  <WebUI>http://[IP]:[PORT:8581]/</WebUI>
+  <Icon>https://raw.githubusercontent.com/homebridge/branding/master/logos/homebridge-color-round-stylized.png</Icon>
+  <DonateText>If you find this project useful please STAR it on GitHub.</DonateText>
+  <DonateLink>https://github.com/oznu/docker-homebridge</DonateLink>
+  <DonateImg>https://user-images.githubusercontent.com/3979615/96548396-85731300-12f9-11eb-9322-951083d43db1.png</DonateImg>
+  <ExtraParams>--shm-size=5G --runtime=nvidia</ExtraParams>
+</Containers>


### PR DESCRIPTION
- Added Dockerfile.ffmpeg.amd64nvidia to build ffmpeg with Nvidia hardware accelerated capabilities.
  - Based on blakeblackshear/frigate-ffmpeg:amd64nvidia which is based on jrottenberg/ffmpeg.
- Added Dockerfile.amd64nvidia to include the ffmpeg that was built and build the necessary base environment to operation within.
  - Based on blakeblackshear/frigate:amd64nvidia which is based on https://gitlab.com/nvidia/container-images/cuda/-/blob/master/dist/11.1.1/ubuntu1804/base/Dockerfile on top of the existing Dockerfile.ubuntu.

If pulled, the XML needs to be updated to reflect oznu repository.