### PR TITLE
Remove deprecated HOMEBRIDGE_CONFIG_UI environment

### DIFF
--- a/homebridge.xml
+++ b/homebridge.xml
@@ -25,12 +25,6 @@
   <Networking>
     <Mode>host</Mode>
   </Networking>
-  <Environment>
-    <Variable>
-      <Name>HOMEBRIDGE_CONFIG_UI_PORT</Name>
-      <Value>8581</Value>
-    </Variable>
-  </Environment>
   <Data>
     <Volume>
       <HostDir>/mnt/user/appdata/homebridge</HostDir>

--- a/rootfs/etc/s6-overlay/s6-rc.d/homebridge/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/homebridge/run
@@ -2,6 +2,7 @@
 
 export HOME=/home/homebridge
 export USER=root
+export HOMEBRIDGE_CONFIG_UI=1
 
 # this is not necessarily the ui version, it's now used as a feature compatibility indicator 
 export CONFIG_UI_VERSION=4.44.2

--- a/rootfs/etc/s6-overlay/s6-rc.d/homebridge/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/homebridge/run
@@ -2,7 +2,6 @@
 
 export HOME=/home/homebridge
 export USER=root
-export HOMEBRIDGE_CONFIG_UI=1
 
 # this is not necessarily the ui version, it's now used as a feature compatibility indicator 
 export CONFIG_UI_VERSION=4.44.2


### PR DESCRIPTION
Remove deprecated `HOMEBRIDGE_CONFIG_UI` environment variable.

Related to: #440