### PR TITLE
Allow home bridge deamon to run as custom user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ ENV S6_OVERLAY_VERSION=3.1.1.2 \
  S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0 \
  S6_KEEP_ENV=1 \
  ENABLE_AVAHI=1 \
- USER=root \
  HOMEBRIDGE_APT_PACKAGE=1 \
  UIX_CUSTOM_PLUGIN_PATH="/var/lib/homebridge/node_modules" \
  PATH="/opt/homebridge/bin:/var/lib/homebridge/node_modules/.bin:$PATH" \
@@ -65,7 +64,7 @@ RUN case "$(uname -m)" in \
   && curl -sSLf -o /homebridge_${HOMEBRIDGE_PKG_VERSION}.deb https://github.com/homebridge/homebridge-apt-pkg/releases/download/${HOMEBRIDGE_PKG_VERSION}/homebridge_${HOMEBRIDGE_PKG_VERSION}_${DEB_ARCH}.deb \
   && dpkg -i /homebridge_${HOMEBRIDGE_PKG_VERSION}.deb \
   && rm -rf /homebridge_${HOMEBRIDGE_PKG_VERSION}.deb \
-  && chown -R root:root /opt/homebridge \
+  && chown -R $PUID:$PGID /opt/homebridge \
   && rm -rf /var/lib/homebridge
 
 COPY rootfs /

--- a/homebridge.xml
+++ b/homebridge.xml
@@ -25,6 +25,16 @@
   <Networking>
     <Mode>host</Mode>
   </Networking>
+  <Environment>
+    <Variable>
+      <Name>PUID</Name>
+      <Value>1000</Value>
+    </Variable>
+    <Variable>
+      <Name>PGID</Name>
+      <Value>100</Value>
+    </Variable>
+  </Environment>
   <Data>
     <Volume>
       <HostDir>/mnt/user/appdata/homebridge</HostDir>

--- a/rootfs/etc/s6-overlay/s6-rc.d/homebridge-log/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/homebridge-log/run
@@ -2,4 +2,6 @@
 
 [ -e /homebridge/homebridge.log ] || touch /homebridge/homebridge.log
 
-exec tail -f --follow=name /homebridge/homebridge.log
+chown $PUID:$PGID /homebridge/homebridge.log
+
+exec s6-setuidgid $PUID:$PGID tail -f --follow=name /homebridge/homebridge.log

--- a/rootfs/etc/s6-overlay/s6-rc.d/homebridge/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/homebridge/run
@@ -1,11 +1,44 @@
 #!/command/with-contenv sh
 
 export HOME=/home/homebridge
-export USER=root
+export USER=homebridge
 export HOMEBRIDGE_CONFIG_UI=1
 
 # this is not necessarily the ui version, it's now used as a feature compatibility indicator 
 export CONFIG_UI_VERSION=4.44.2
 
-# start homebridge
-exec /opt/homebridge/start.sh --allow-root
+# fix permissions
+ fix_permissions() {
+   find /homebridge -type d -exec chmod 755 {} \;
+   chmod -R u+rw /homebridge
+   chown -R $PUID:$PGID /homebridge 
+   if [ "$?" != "0" ]; then
+     echo "Failed to set permissions on /homebridge; the Homebridge service will run as root."
+     return 1
+   fi
+ }
+
+ # check if the UI is running on a privileged port
+ ui_port_check() {
+   if [ -f /var/lib/homebridge/config.json ]; then
+     ui_port=$(cat /var/lib/homebridge/config.json | jq -rM '.platforms[] | select(.platform == "config") | .port' 2> /dev/null)
+     if [ "$?" = "0" ] && [ "$ui_port" -le 1024 ]; then
+       echo "The Homebridge UI has been configured to run on a privileged port ($ui_port); the Homebridge service will run as root."
+       return 1
+     fi
+   fi
+ }
+
+ if ! fix_permissions; then
+   # if we can't set permissions on /homebridge, run Homebridge as "root", it's not ideal, but it's better than nothing
+   exec /opt/homebridge/start.sh --allow-root
+ elif ! ui_port_check; then
+   # the UI is running on a privileged port, run Homebridge as "root"
+   exec /opt/homebridge/start.sh --allow-root
+ elif [ "$PUID" = "0" ] || [ "$PGID" = "0" ]; then
+   # the user wants homebridge to run as root
+   exec /opt/homebridge/start.sh --allow-root
+ else
+   # standard operation, run as homebridge user (this could still be "root" if PUID and PGID are set to 0)
+   exec s6-setuidgid $PUID:$PGID /opt/homebridge/start.sh --allow-root
+ fi

--- a/rootfs/etc/s6-overlay/s6-rc.d/homebridge/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/homebridge/run
@@ -40,5 +40,5 @@ export CONFIG_UI_VERSION=4.44.2
    exec /opt/homebridge/start.sh --allow-root
  else
    # standard operation, run as homebridge user (this could still be "root" if PUID and PGID are set to 0)
-   exec s6-setuidgid $PUID:$PGID /opt/homebridge/start.sh --allow-root
+   exec s6-setuidgid $PUID:$PGID /opt/homebridge/start.sh
  fi

--- a/rootfs/etc/systemd/system/homebridge.service.d/override.conf
+++ b/rootfs/etc/systemd/system/homebridge.service.d/override.conf
@@ -1,5 +1,0 @@
-# this docker container does not use systemd
-# the homebridge apt package just checks this file to see if the user has been changed from the default
-
-[Service]
-User=root


### PR DESCRIPTION
Restore use of PUID and PGID to set the user and group us to run homebridge and avoid having to use root.