### PR TITLE
Bump package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ LABEL org.opencontainers.image.licenses="GPL-3.0"
 
 # update to latest releases prior to release
 
-ENV HOMEBRIDGE_PKG_VERSION=1.1.6 \
+ENV HOMEBRIDGE_PKG_VERSION=1.2.0 \
   FFMPEG_VERSION=v2.1.1
 
 ENV S6_OVERLAY_VERSION=3.1.1.2 \


### PR DESCRIPTION
## :recycle: Current situation

Docker image contains an older version of the APT package.

## :bulb: Proposed solution

Update to the latest version: https://github.com/homebridge/homebridge-apt-pkg/releases/tag/1.2.0

## :gear: Release Notes

N/A

## :heavy_plus_sign: Additional Information
N/A

### Testing
N/A

### Reviewer Nudging

N/A
