### PR TITLE
[README] Update Docker Limitation for Windows / macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ This is a multi-arch image and will run on x86_64, Raspberry Pi 2, 3, 4, Zero 2 
 
 Homebridge requires full access to your local network to function correctly which can be achieved using the ```--net=host``` flag.
 
-**This image will not work when using [Docker for Mac](https://docs.docker.com/docker-for-mac/) or [Docker for Windows](https://docs.docker.com/docker-for-windows/) due to [this](https://github.com/docker/for-mac/issues/68) and [this](https://github.com/docker/for-win/issues/543)**.
-
+**This image will not work when using [Docker for Mac](https://docs.docker.com/docker-for-mac/) or [Docker for Windows](https://docs.docker.com/docker-for-windows/) due to [this](https://github.com/homebridge/docker-homebridge/issues/570)**.
 
 ## Usage
 


### PR DESCRIPTION
I have not tested that the limitation exists on Windows as described here, so it either works on Windows and not macOS, or it continues to work on neither.

I briefly went down the rabbithole to see if I could get it working, then came across the new issue.