### PR TITLE
Update to latest version of Homebridge

### DIFF
--- a/rootfs/etc/s6-overlay/scripts/setup.sh
+++ b/rootfs/etc/s6-overlay/scripts/setup.sh
@@ -57,10 +57,15 @@ if [ -e /homebridge/pnpm-lock.yaml ]; then
   rm -rf /homebridge/package-lock.json
 fi
 
-# setup initial package.json with homebridge
+# get latest version of homebridge
+HOMEBRIDGE_VERSION="$(curl -sf https://registry.npmjs.org/homebridge/latest | jq -r '.version')"
+
+# if package.json doesn't exist setup initial version, else update to latest version
 if [ ! -e /homebridge/package.json ]; then
-  HOMEBRIDGE_VERSION="$(curl -sf https://registry.npmjs.org/homebridge/latest | jq -r '.version')"
   echo "{ \"dependencies\": { \"homebridge\": \"$HOMEBRIDGE_VERSION\" }}" | jq . > /homebridge/package.json
+else
+  packageJson="$(jq --arg hb_version "$HOMEBRIDGE_VERSION" '.dependencies += { "homebridge":$hb_version }' /homebridge/package.json)"
+  echo $packageJson | jq . > /homebridge/package.json
 fi
 
 # remove homebridge-config-ui-x from the package.json


### PR DESCRIPTION
## :recycle: Current situation

When a new image is deployed, it checks to see if `package.json` is present. If it isn't, it creates a new file and populates it with the latest version of Homebridge. If the file is present it does not update it. So if `package.json` contains a previous version of Homebridge is present, the new image deploys the older version contained in it.

## :bulb: Proposed solution

When a new image is deployed, if `package.json` exists, it updates it to the latest version of Homebridge, so the new image deploys the latest version.

## :gear: Release Notes

Edited `rootfs/etc/s6-overlay/scripts/setup.sh`.

## :heavy_plus_sign: Additional Information

N/A

### Testing

N/A

### Reviewer Nudging

N/A
