### PR TITLE
Set HB & HB UI versions for image and update HB & HB UI if update versions ahead of current

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,7 @@ RUN case "$(uname -m)" in \
   && rm -rf /var/lib/homebridge
 
 COPY rootfs /
+COPY package-config-docker.json /
 
 EXPOSE 8581/tcp
 VOLUME /homebridge

--- a/README.md
+++ b/README.md
@@ -98,13 +98,17 @@ You can update Homebridge and Homebridge UI in different ways:
 * from the command line inside the container
 * by updating the Docker image version in the `docker-compose.yml` file
 
-The Docker image comes with predefined versions of Homebridge, Homebridge UI and Node.js. If the currently installed versions are behind the versions defined by the image, your Homebridge and Homebridge UI will be updated to the image versions. If the currently installed versions are ahead of the version provided by the image, the installed versions will not be downgraded.
+The Docker image comes with predefined versions of Homebridge, Homebridge UI and Node.js.<br />
+If the currently installed versions of Homebridge or Homebridge UI are behind the versions defined by the image, your Homebridge and Homebridge UI will be updated to the image versions.<br />
+If the currently installed versions are ahead of the version provided by the image, the installed versions will not be downgraded.
 
 For example:
 * If you have Homebridge UI v1.1.9 installed and the version defined by the image is v1.2.0, the installed version will be updated to v1.2.0.
 * If you have Homebridge UI v1.2.1 installed and the version defined by the image is v1.2.0, the installed version will remain v1.2.1.
 
-**Note:** While it is also possible to update the Node.js runtime from the command line inside the Docker container, it is **strongly discouraged** and done at your own risk. It is **strongly recommended** that Node.js be updated only by updating to the latest Docker image, as outlined in the `Docker` section of this document: [How-To-Update-Node.js](https://github.com/homebridge/homebridge/wiki/How-To-Update-Node.js#docker). Also, **recreating a Docker container will always overwrite any manual updates of Node.js.**
+**Note:** While it is also possible to update the Node.js runtime from the command line inside the Docker container, it is **strongly discouraged** and done at your own risk. It is **strongly recommended** that Node.js be updated only by updating to the latest Docker image, as outlined in the `Docker` section of this document: [How-To-Update-Node.js](https://github.com/homebridge/homebridge/wiki/How-To-Update-Node.js#docker).
+
+**Note: recreating a Docker container will always overwrite any manual updates of Node.js.**
 
 ## Automated Updates
 

--- a/README.md
+++ b/README.md
@@ -91,11 +91,23 @@ To manage Homebridge go to `http://<ip of server>:8581` in your browser. For exa
   <img width="600px" src="https://user-images.githubusercontent.com/3979615/71886653-b16d3f80-3190-11ea-9ff8-49dc4ae4fff0.png">
 </p>
 
+## Updates
+
+You can update Homebridge and Homebridge UI in different ways:
+* from the Update Information widget in the Homebridge UI
+* from the command line inside the container
+* by updating the Docker image version in the `docker-compose.yml` file
+
+If you update the Docker image, the image will come with a defined version of Homebridge and Homebridge UI. If the currently installed versions are behind the versions defined by the image, your Homebridge and Homebridge UI will be updated to the image versions. If you have installed a version ahead of the version provided by the image, the installed version will not be downgraded.
+For example:
+If you have Homebridge UI v1.1.9 installed and the version defined by the image is v1.2.0, the installed version will be updated to v1.2.0.
+If you have Homebridge UI v1.2.1 installed and the version defined by the image is v1.2.0, the installed version will remain v1.2.1.
+
+**Note:** While it is also possible to update the Node.js runtime from the command line inside the container, it is **strongly discouraged** and done at your own risk. It is **strongly recommended** that Node.js be updated only by updating to the latest Docker image, as outlined in the Docker section of this document: [How-To-Update-Node.js](https://github.com/homebridge/homebridge/wiki/How-To-Update-Node.js#docker). Also, recreating the Docker comntainer will always overwrite any manual updates of Node.js.
+
 ## Automated Updates
 
 Automated updates of the Homebridge Docker Image using tools such as Watchtower or similar are strongly discouraged and are done so at your own risk.
-
-**NOTE** - The version of Homebridge **IS NOT** tied to the version of the container.  You can update Homebridge, the Homebridge UI and the Node.js runtime from inside the container.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ You can update Homebridge and Homebridge UI in different ways:
 
 The Docker image comes with predefined versions of Homebridge, Homebridge UI and Node.js.<br />
 If the currently installed versions of Homebridge or Homebridge UI are behind the versions defined by the image, your Homebridge and Homebridge UI will be updated to the image versions.<br />
-If the currently installed versions are ahead of the version provided by the image, the installed versions will not be downgraded.
+If the currently installed versions of Homebridge or Homebridge UI are ahead of the version provided by the image, the installed versions will not be downgraded.
 
 For example:
 * If you have Homebridge UI v1.1.9 installed and the version defined by the image is v1.2.0, the installed version will be updated to v1.2.0.

--- a/README.md
+++ b/README.md
@@ -98,13 +98,13 @@ You can update Homebridge and Homebridge UI in different ways:
 * from the command line inside the container
 * by updating the Docker image version in the `docker-compose.yml` file
 
-If you update the Docker image, the image will come with a defined version of Homebridge and Homebridge UI. If the currently installed versions are behind the versions defined by the image, your Homebridge and Homebridge UI will be updated to the image versions. If you have installed a version ahead of the version provided by the image, the installed version will not be downgraded.
+The Docker image comes with predefined versions of Homebridge, Homebridge UI and Node.js. If the currently installed versions are behind the versions defined by the image, your Homebridge and Homebridge UI will be updated to the image versions. If the currently installed versions are ahead of the version provided by the image, the installed versions will not be downgraded.
 
 For example:
 * If you have Homebridge UI v1.1.9 installed and the version defined by the image is v1.2.0, the installed version will be updated to v1.2.0.
 * If you have Homebridge UI v1.2.1 installed and the version defined by the image is v1.2.0, the installed version will remain v1.2.1.
 
-**Note:** While it is also possible to update the Node.js runtime from the command line inside the container, it is **strongly discouraged** and done at your own risk. It is **strongly recommended** that Node.js be updated only by updating to the latest Docker image, as outlined in the Docker section of this document: [How-To-Update-Node.js](https://github.com/homebridge/homebridge/wiki/How-To-Update-Node.js#docker). Also, recreating the Docker container will always overwrite any manual updates of Node.js.
+**Note:** While it is also possible to update the Node.js runtime from the command line inside the Docker container, it is **strongly discouraged** and done at your own risk. It is **strongly recommended** that Node.js be updated only by updating to the latest Docker image, as outlined in the `Docker` section of this document: [How-To-Update-Node.js](https://github.com/homebridge/homebridge/wiki/How-To-Update-Node.js#docker). Also, **recreating a Docker container will always overwrite any manual updates of Node.js.**
 
 ## Automated Updates
 

--- a/README.md
+++ b/README.md
@@ -99,11 +99,12 @@ You can update Homebridge and Homebridge UI in different ways:
 * by updating the Docker image version in the `docker-compose.yml` file
 
 If you update the Docker image, the image will come with a defined version of Homebridge and Homebridge UI. If the currently installed versions are behind the versions defined by the image, your Homebridge and Homebridge UI will be updated to the image versions. If you have installed a version ahead of the version provided by the image, the installed version will not be downgraded.
-For example:
-If you have Homebridge UI v1.1.9 installed and the version defined by the image is v1.2.0, the installed version will be updated to v1.2.0.
-If you have Homebridge UI v1.2.1 installed and the version defined by the image is v1.2.0, the installed version will remain v1.2.1.
 
-**Note:** While it is also possible to update the Node.js runtime from the command line inside the container, it is **strongly discouraged** and done at your own risk. It is **strongly recommended** that Node.js be updated only by updating to the latest Docker image, as outlined in the Docker section of this document: [How-To-Update-Node.js](https://github.com/homebridge/homebridge/wiki/How-To-Update-Node.js#docker). Also, recreating the Docker comntainer will always overwrite any manual updates of Node.js.
+For example:
+* If you have Homebridge UI v1.1.9 installed and the version defined by the image is v1.2.0, the installed version will be updated to v1.2.0.
+* If you have Homebridge UI v1.2.1 installed and the version defined by the image is v1.2.0, the installed version will remain v1.2.1.
+
+**Note:** While it is also possible to update the Node.js runtime from the command line inside the container, it is **strongly discouraged** and done at your own risk. It is **strongly recommended** that Node.js be updated only by updating to the latest Docker image, as outlined in the Docker section of this document: [How-To-Update-Node.js](https://github.com/homebridge/homebridge/wiki/How-To-Update-Node.js#docker). Also, recreating the Docker container will always overwrite any manual updates of Node.js.
 
 ## Automated Updates
 

--- a/package-config-docker.json
+++ b/package-config-docker.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "homebridge": "1.9.0",
+    "homebridge-config-ui-x": "4.71.0"
+  }
+}

--- a/rootfs/etc/s6-overlay/scripts/setup.sh
+++ b/rootfs/etc/s6-overlay/scripts/setup.sh
@@ -63,15 +63,17 @@ if [ -e /homebridge/pnpm-lock.yaml ]; then
   rm -rf /homebridge/package-lock.json
 fi
 
-# setup initial package.json with homebridge
+# Get image provided versions of Homebridge and Homebridge UI
+hb_update="$(cat /package-config-docker.json | jq -r '.dependencies."homebridge"' | tr -dc [0-9\.])"
+hbui_update="$(cat /package-config-docker.json | jq -r '.dependencies."homebridge-config-ui-x"' | tr -dc [0-9\.])"
+
+# setup initial package.json with Homebridge and Homebridge UI image versions
 if [ ! -e /homebridge/package.json ]; then
-  HOMEBRIDGE_VERSION="$(curl -sf https://registry.npmjs.org/homebridge/latest | jq -r '.version')"
-  echo "{ \"dependencies\": { \"homebridge\": \"$HOMEBRIDGE_VERSION\" }}" | jq . > /homebridge/package.json
+  echo "{ \"dependencies\": { \"homebridge\": \"$hb_update\", \"homebridge-config-ui-x\": \"$hbui_update\" }}" | jq . > /homebridge/package.json
 else
   # Update Homebridge version if update is ahead of current
   # Handles if no current version is found - update is ahead of no version
   hb_current="$(cat /homebridge/package.json | jq -r '.dependencies."homebridge"' | tr -dc [0-9\.])"
-  hb_update="$(cat /package-config-docker.json | jq -r '.dependencies."homebridge"' | tr -dc [0-9\.])"
 
   if [ $(version $hb_update) -gt $(version $hb_current) ]; then
       packageJson="$(jq --arg hb_version "$hb_update" '.dependencies += { "homebridge":$hb_version }' /homebridge/package.json)"
@@ -81,7 +83,6 @@ else
   # Update Homebridge UI version if update is ahead of current
   # Handles if no current version is found - update is ahead of no version
   hbui_current="$(cat /homebridge/package.json | jq -r '.dependencies."homebridge-config-ui-x"' | tr -dc [0-9\.])"
-  hbui_update="$(cat /package-config-docker.json | jq -r '.dependencies."homebridge-config-ui-x"' | tr -dc [0-9\.])"
 
   if [ $(version $hbui_update) -gt $(version $hbui_current) ]; then
       packageJson="$(jq --arg hbui_version "$hbui_update" '.dependencies += { "homebridge-config-ui-x":$hbui_version }' /homebridge/package.json)"

--- a/rootfs/etc/s6-overlay/scripts/setup.sh
+++ b/rootfs/etc/s6-overlay/scripts/setup.sh
@@ -1,5 +1,11 @@
 #!/command/with-contenv sh
 
+# Compare dotted versions, e.g.: 1.9.0
+# Supports supports versions with up to four components up to three digits each
+function version {
+    echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }';
+}
+
 # make folders
 mkdir -p /var/run/dbus
 mkdir -p /var/run/avahi-daemon
@@ -61,16 +67,25 @@ fi
 if [ ! -e /homebridge/package.json ]; then
   HOMEBRIDGE_VERSION="$(curl -sf https://registry.npmjs.org/homebridge/latest | jq -r '.version')"
   echo "{ \"dependencies\": { \"homebridge\": \"$HOMEBRIDGE_VERSION\" }}" | jq . > /homebridge/package.json
-fi
+else
+  # Update Homebridge version if update is ahead of current
+  # Handles if no current version is found - update is ahead of no version
+  hb_current="$(cat /homebridge/package.json | jq -r '.dependencies."homebridge"' | tr -dc [0-9\.])"
+  hb_update="$(cat /package-config-docker.json | jq -r '.dependencies."homebridge"' | tr -dc [0-9\.])"
 
-# remove homebridge-config-ui-x from the package.json
-if [ -e /homebridge/package.json ]; then
-  if [ "$(cat /homebridge/package.json | jq -r '.dependencies."homebridge-config-ui-x"')" != "null" ]; then
-    packageJson="$(cat /homebridge/package.json | jq -rM 'del(."dependencies"."homebridge-config-ui-x")')"
-    if [ "$?" = "0" ]; then
-      printf "$packageJson" > /homebridge/package.json
-      echo "Removed homebridge-config-ui-x from package.json"
-    fi
+  if [ $(version $hb_update) -gt $(version $hb_current) ]; then
+      packageJson="$(jq --arg hb_version "$hb_update" '.dependencies += { "homebridge":$hb_version }' /homebridge/package.json)"
+      echo $packageJson | jq . > /homebridge/package.json
+  fi
+
+  # Update Homebridge UI version if update is ahead of current
+  # Handles if no current version is found - update is ahead of no version
+  hbui_current="$(cat /homebridge/package.json | jq -r '.dependencies."homebridge-config-ui-x"' | tr -dc [0-9\.])"
+  hbui_update="$(cat /package-config-docker.json | jq -r '.dependencies."homebridge-config-ui-x"' | tr -dc [0-9\.])"
+
+  if [ $(version $hbui_update) -gt $(version $hbui_current) ]; then
+      packageJson="$(jq --arg hbui_version "$hbui_update" '.dependencies += { "homebridge-config-ui-x":$hbui_version }' /homebridge/package.json)"
+      echo $packageJson | jq . > /homebridge/package.json
   fi
 fi
 


### PR DESCRIPTION
## :recycle: Current situation

On clean install, Docker image installs latest version of Homebridge and Homebridge UI.
On update install, Docker image does not install any version of Homebridge and latest version of Homebridge UI.

This behavior is not consistent and confusing. Also, there is no option to roll back to a specific image to get a known-good installation.

## :bulb: Proposed solution

Docker image provides set versions of Homebridge and Homebridge UI. This allows to roll back to a specific image to get a known-good installation.

On clean install, Docker image installs image version of Homebridge and Homebridge UI.
On update install, Docker image installs image version of Homebridge if it is ahead of currently installed Homebridge version, and installs image version of Homebridge UI if it is ahead of currently installed Homebridge UI version.

Handles following scenarios:
- Version is declared in `/homebridge/package.json` as "1.9.0". Compares if image version is ahead of "1.9.0".
- Version is declared in `/homebridge/package.json` as "^1.9.0". Compares if image version is ahead of "1.9.0".
- No version is found in `/homebridge/package.json`. Image version is always ahead.

Handles the following scenario:
- Version is declared in `/homebridge/package.json` as "1.9.0-beta.1". Compares if image version is ahead of "1.9.0.1".

"1.9.0" is converted as "1" -> "001", "9" -> "009", "0" -> "000", "" -> "000" -> 1009000000
"1.9.0.1" is converted as "1" -> "001", "9" -> "009", "0" -> "000", "1" -> "000" -> 1009000001

So a beta version will be evaluated as ahead of the release version. While this is not true, if the user is installing beta builds, maybe they are doing some development, or doing some testing of some sort, so the install should not overwrite their custom environment. If they are playing with betas, they know enough about updating versions and should expect to manually update to the latest release. Maybe this should be described in the `README.md` file.

## :memo: Note

Prior to publishing a new Docker image, update `package-config-docker.json` to the Homebridge and Homebridge UI versions that this image will install.