### PR TITLE
Add healthcheck into the container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,4 +115,7 @@ EXPOSE 8581/tcp
 VOLUME /homebridge
 WORKDIR /homebridge
 
+HEALTHCHECK --interval=60s --retries=5 --start-period=300s --timeout=2s \
+  CMD curl --fail http://localhost:8581 || exit 1
+
 ENTRYPOINT [ "/init" ]


### PR DESCRIPTION
## :recycle: Current situation

Wanted to add a healthcheck to the container, noticed the example in the readme and though. Why not add it by default into the container?

## :bulb: Proposed solution

Adding it into the dockerfile, so it's pre-defined. Kinda like [gethomepage does it](https://github.com/gethomepage/homepage/blob/dev/Dockerfile#L61).

## :gear: Release Notes

Added this before the entrypoint:

```bash
HEALTHCHECK --interval=60s --retries=5 --start-period=300s --timeout=2s \
  CMD curl --fail http://localhost:8581 || exit 1
```

## :heavy_plus_sign: Additional Information

Based on the information provided here: https://github.com/homebridge/docker-homebridge/blob/latest/README.md?plain=1#L67

### Testing

None, it initself is a test!

### Reviewer Nudging

Not applicable.