### PR TITLE
Offer a Ubuntu 22.04 Kernel for Synology Users - fix for #960

### DIFF
--- a/.github/homebridge-dependency-bot-synology.json
+++ b/.github/homebridge-dependency-bot-synology.json
@@ -1,0 +1,22 @@
+{
+  "auto_merge": true,
+  "git_user": {
+    "name": "Homebridge Dependency Bot",
+    "email": "actions@github.com"
+  },
+  "directories": [
+    {
+      "directory": ".",
+      "packages": [
+        {
+          "name": "@homebridge/homebridge-apt-pkg",
+          "tag": "latest"
+        },
+        {
+          "name": "ffmpeg-for-homebridge",
+          "tag": "latest"
+        }
+      ]
+    }
+  ]
+}

--- a/.github/homebridge-dependency-bot-synology.json
+++ b/.github/homebridge-dependency-bot-synology.json
@@ -6,7 +6,7 @@
   },
   "directories": [
     {
-      "directory": ".",
+      "directory": "synology",
       "packages": [
         {
           "name": "@homebridge/homebridge-apt-pkg",

--- a/.github/workflows/release-stage-1_update_dependencies.yml
+++ b/.github/workflows/release-stage-1_update_dependencies.yml
@@ -52,7 +52,7 @@ jobs:
               echo "matrix={\"stream\":[\"${{ github.event.inputs.release_stream }}\"]}" >> $GITHUB_OUTPUT
             fi
           else
-            # Scheduled run - process stable, beta, and alpha streams
+            # Scheduled run - process stable, beta, legacy, synology and alpha streams
             echo 'matrix={"stream":["stable","beta","alpha","legacy","synology"]}' >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/release-stage-1_update_dependencies.yml
+++ b/.github/workflows/release-stage-1_update_dependencies.yml
@@ -16,6 +16,7 @@ on:
           - beta
           - alpha
           - legacy
+          - synology
           - all
         default: all
       skip_build:
@@ -46,13 +47,13 @@ jobs:
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             if [[ "${{ github.event.inputs.release_stream }}" == "all" ]]; then
-              echo 'matrix={"stream":["stable","beta","alpha","legacy"]}' >> $GITHUB_OUTPUT
+              echo 'matrix={"stream":["stable","beta","alpha","legacy","synology"]}' >> $GITHUB_OUTPUT
             else
               echo "matrix={\"stream\":[\"${{ github.event.inputs.release_stream }}\"]}" >> $GITHUB_OUTPUT
             fi
           else
             # Scheduled run - process stable, beta, and alpha streams
-            echo 'matrix={"stream":["stable","beta","alpha","legacy"]}' >> $GITHUB_OUTPUT
+            echo 'matrix={"stream":["stable","beta","alpha","legacy","synology"]}' >> $GITHUB_OUTPUT
           fi
 
       - name: Output matrix for debugging

--- a/.github/workflows/release-stage-2_build_and_push_docker_images.yml
+++ b/.github/workflows/release-stage-2_build_and_push_docker_images.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       release_type:
-        description: 'Choose release type: stable, beta, alpha, or legacy.'
+        description: 'Choose release type: stable, beta, alpha, synology or legacy.'
         required: true
         type: choice
         options:
@@ -13,6 +13,7 @@ on:
           - beta
           - alpha
           - legacy
+          - synology
         default: beta
       Scheduled:
         description: 'Whether this is a scheduled run'
@@ -120,6 +121,12 @@ jobs:
         ARGS="HOMEBRIDGE_APT_PKG_VERSION=${{ needs.set-versions.outputs.HOMEBRIDGE_APT_PKG_VERSION }}
         FFMPEG_FOR_HOMEBRIDGE_VERSION=${{ needs.set-versions.outputs.FFMPEG_FOR_HOMEBRIDGE_VERSION }}
         DOCKER_HOMEBRIDGE_VERSION=${{ needs.set-versions.outputs.DOCKER_HOMEBRIDGE_VERSION }}"
+
+        // If a synology release, we need to pass BASE_IMAGE=22.04 to build args, and if it's a stable release we need to pass the apt pkg file name
+         if [[ "${{ inputs.release_type }}" == "synology" ]]; then
+          ARGS="$ARGS
+        BASE_IMAGE=22.04"
+        fi
 
         if [[ "${{ needs.set-versions.outputs.IS_STABLE }}" == "false" ]]; then
           ARGS="$ARGS

--- a/.github/workflows/release-stage-2_build_and_push_docker_images.yml
+++ b/.github/workflows/release-stage-2_build_and_push_docker_images.yml
@@ -122,12 +122,13 @@ jobs:
         FFMPEG_FOR_HOMEBRIDGE_VERSION=${{ needs.set-versions.outputs.FFMPEG_FOR_HOMEBRIDGE_VERSION }}
         DOCKER_HOMEBRIDGE_VERSION=${{ needs.set-versions.outputs.DOCKER_HOMEBRIDGE_VERSION }}"
 
-        // If a synology release, we need to pass BASE_IMAGE=22.04 to build args, and if it's a stable release we need to pass the apt pkg file name
-         if [[ "${{ inputs.release_type }}" == "synology" ]]; then
+        # If a synology release, we need to pass BASE_IMAGE=22.04 to build args
+        if [[ "${{ inputs.release_type }}" == "synology" ]]; then
           ARGS="$ARGS
         BASE_IMAGE=22.04"
         fi
 
+        # If a pre-release, we need to pass the apt pkg file name
         if [[ "${{ needs.set-versions.outputs.IS_STABLE }}" == "false" ]]; then
           ARGS="$ARGS
         HOMEBRIDGE_APT_PKG_FILE=${{ needs.set-versions.outputs.HOMEBRIDGE_APT_PKG_FILE }}"

--- a/.github/workflows/release-stage-2_build_and_push_docker_images.yml
+++ b/.github/workflows/release-stage-2_build_and_push_docker_images.yml
@@ -118,6 +118,7 @@ jobs:
       id: build_args
       run: |
         ARGS="HOMEBRIDGE_APT_PKG_VERSION=${{ needs.set-versions.outputs.HOMEBRIDGE_APT_PKG_VERSION }}
+        HOMEBRIDGE_APT_PKG_FILE=${{ needs.set-versions.outputs.HOMEBRIDGE_APT_PKG_FILE }}
         FFMPEG_FOR_HOMEBRIDGE_VERSION=${{ needs.set-versions.outputs.FFMPEG_FOR_HOMEBRIDGE_VERSION }}
         DOCKER_HOMEBRIDGE_VERSION=${{ needs.set-versions.outputs.DOCKER_HOMEBRIDGE_VERSION }}"
 
@@ -127,11 +128,6 @@ jobs:
         BASE_IMAGE=22.04"
         fi
 
-        # If a pre-release, we need to pass the apt pkg file name
-        if [[ "${{ needs.set-versions.outputs.IS_STABLE }}" == "false" ]]; then
-          ARGS="$ARGS
-        HOMEBRIDGE_APT_PKG_FILE=${{ needs.set-versions.outputs.HOMEBRIDGE_APT_PKG_FILE }}"
-        fi
         echo "args<<EOF" >> $GITHUB_OUTPUT
         echo "$ARGS" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-stage-2_build_and_push_docker_images.yml
+++ b/.github/workflows/release-stage-2_build_and_push_docker_images.yml
@@ -73,11 +73,9 @@ jobs:
         HOMEBRIDGE_APT_PKG_VERSION=$(jq -r '.dependencies["@homebridge/homebridge-apt-pkg"]' "$PKG_FILE" | sed 's/\^//')
         FFMPEG_FOR_HOMEBRIDGE_VERSION=$(jq -r '.dependencies["ffmpeg-for-homebridge"]' "$PKG_FILE" | sed 's/\^//')
 
-        # For pre-release types, transform the apt pkg filename (e.g. 1.0.0-beta.1 → 1.0.0.beta.1)
-        if [[ "$IS_STABLE" == "false" ]]; then
-          HOMEBRIDGE_APT_PKG_FILE=$(echo "$HOMEBRIDGE_APT_PKG_VERSION" | sed "s/\([0-9]*\.[0-9]*\.[0-9]*\)-${DOCKER_TAG}\(\.[0-9]*\)/\1.${DOCKER_TAG}\2/")
-          echo "HOMEBRIDGE_APT_PKG_FILE=v${HOMEBRIDGE_APT_PKG_FILE}" >> $GITHUB_OUTPUT
-        fi
+        # Transform apt pkg filename: X.Y.Z-prerelease.N → X.Y.Z.prerelease.N (Debian naming)
+        # Stable versions (e.g. 2.0.2) pass through unchanged
+        HOMEBRIDGE_APT_PKG_FILE=$(echo "$HOMEBRIDGE_APT_PKG_VERSION" | sed 's/\([0-9]*\.[0-9]*\.[0-9]*\)-\([a-zA-Z][a-zA-Z0-9]*\)\(\.[0-9]*\)/\1.\2\3/')
 
         {
           echo "DOCKER_HOMEBRIDGE_VERSION=${DOCKER_HOMEBRIDGE_VERSION}"
@@ -85,6 +83,7 @@ jobs:
           echo "RELEASE_TITLE=${RELEASE_TITLE}"
           echo "IS_STABLE=${IS_STABLE}"
           echo "HOMEBRIDGE_APT_PKG_VERSION=v${HOMEBRIDGE_APT_PKG_VERSION}"
+          echo "HOMEBRIDGE_APT_PKG_FILE=v${HOMEBRIDGE_APT_PKG_FILE}"
           echo "FFMPEG_FOR_HOMEBRIDGE_VERSION=v${FFMPEG_FOR_HOMEBRIDGE_VERSION}"
         } >> $GITHUB_OUTPUT
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM ubuntu:24.04
+ARG BASE_IMAGE=24.04
+FROM ubuntu:${BASE_IMAGE}
+
+# Re-declare ARG after FROM to make it available in RUN steps
+ARG BASE_IMAGE=24.04
 
 LABEL org.opencontainers.image.title="Homebridge in Docker"
 LABEL org.opencontainers.image.description="Official Homebridge Docker Image"
@@ -87,7 +91,7 @@ RUN HB_CONFIG_UI_X_VERSION=$(jq -r '.dependencies["homebridge-config-ui-x"]' /op
   "Release Version: ${DOCKER_HOMEBRIDGE_VERSION}\n\n" \
   "| Package | Version |\n" \
   "|:-------:|:-------:|\n" \
-  "|Ubuntu|24.04|\n" \
+  "|Ubuntu|${BASE_IMAGE}|\n" \
   "|ffmpeg for homebridge|${FFMPEG_FOR_HOMEBRIDGE_VERSION}|\n" \
   "|Homebridge APT Package|${HOMEBRIDGE_APT_PKG_VERSION}|\n" \
   "|NodeJS|$(jq -r '.dependencies.node' /opt/homebridge/package.json)|\n" \

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Please update your configurations to use the new image location for the latest u
 
 ## 📦 Available Images
 
-This is a **multi-architecture** Ubuntu 24.04-based image supporting x86_64, ARM32v7 (Raspberry Pi), and ARM64v8 platforms.
+This is a **multi-architecture** image supporting x86_64, ARM32v7 (Raspberry Pi), and ARM64v8 platforms. Images are available with Ubuntu 24.04 (default) and Ubuntu 22.04 (for Synology compatibility) base images.
 
 | Image Tag | Architectures | Base Image | Release Type | Description |
 |:----------|:--------------|:-----------|:-------------|:------------|

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This is a **multi-architecture** Ubuntu 24.04-based image supporting x86_64, ARM
 |:----------|:--------------|:-----------|:-------------|:------------|
 | `latest`, `ubuntu` | amd64, arm32v7, arm64v8 | Ubuntu 24.04 | **Stable** | Production-ready with latest stable releases |
 | `legacy` | amd64, arm32v7, arm64v8 | Ubuntu 24.04 | **Legacy** | Production-ready with Homebridge 1.x stable releases |
+| `synology` | amd64, arm32v7, arm64v8 | Ubuntu 22.04 | **Stable** | Production-ready with latest stable releases |
 | `beta` | amd64, arm32v7, arm64v8 | Ubuntu 24.04 | **Beta** | Pre-release with beta versions for testing |
 | `alpha` | amd64, arm32v7, arm64v8 | Ubuntu 24.04 | **Alpha** | Early access with alpha versions for development |
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Please update your configurations to use the new image location for the latest u
 
 ## 📦 Available Images
 
-This is a **multi-architecture** Ubuntu 24.04-based image supporting x86_64, ARM32v7 (Raspberry Pi), and ARM64v8 platforms.
+This is a **multi-architecture** Ubuntu 22.04/24.04-based image supporting x86_64, ARM32v7 (Raspberry Pi), and ARM64v8 platforms.
 
 | Image Tag | Architectures | Base Image | Release Type | Description |
 |:----------|:--------------|:-----------|:-------------|:------------|

--- a/assets/release-body-header.md
+++ b/assets/release-body-header.md
@@ -7,6 +7,7 @@ This is a multi-arch image and will run on x86_64, Raspberry Pi 2, 3, 4, Zero 2 
 | Image Tag             | Architectures           | Base Image         | Release Type |
 | :-------------------- | :-----------------------| :----------------- | :----------- |
 | latest, ubuntu        | amd64, arm32v7, arm64v8 | Ubuntu 24.04       | Stable       |
+| synology              | amd64, arm32v7, arm64v8 | Ubuntu 22.04       | Stable       |
 | beta                  | amd64, arm32v7, arm64v8 | Ubuntu 24.04       | Beta         |
 | alpha                 | amd64, arm32v7, arm64v8 | Ubuntu 24.04       | Alpha        | 
 | legacy                | amd64, arm32v7, arm64v8 | Ubuntu 24.04       | Legacy       | 

--- a/rootfs/etc/s6-overlay/scripts/setup.sh
+++ b/rootfs/etc/s6-overlay/scripts/setup.sh
@@ -53,7 +53,7 @@ cd /homebridge
 
 # test jq is functioning correctly
 if ! JQ_TEST_ERROR="$(jq -n '{}' 2>&1 >/dev/null)"; then
-  echo "ERROR: jq failed during setup check: ${JQ_TEST_ERROR:-jq test failed with no error output}"
+  echo "ERROR: jq failed during setup check: ${JQ_TEST_ERROR:-jq test failed with no error output. This may indicate a system compatibility issue.}"
   if echo "$JQ_TEST_ERROR" | grep -qi "cannot get entropy for arc4random"; then
     echo "ERROR: Detected the Synology kernel entropy issue from #960. See https://github.com/homebridge/docker-homebridge/issues/960 for details."
   fi

--- a/rootfs/etc/s6-overlay/scripts/setup.sh
+++ b/rootfs/etc/s6-overlay/scripts/setup.sh
@@ -52,9 +52,12 @@ cd /homebridge
 
 
 # test jq is functioning correctly
-if ! echo '{}' | jq . > /dev/null 2>&1; then
-  echo "ERROR: Issue detected with Host Kernel Version - see https://github.com/homebridge/docker-homebridge/issues/960 for details."
-  echo "ERROR: Stopping setup script to prevent potential issues with Homebridge setup. Please see the above link for details and a resolution."
+if ! JQ_TEST_ERROR="$(echo '{}' | jq . 2>&1 >/dev/null)"; then
+  echo "ERROR: jq failed during setup check: ${JQ_TEST_ERROR:-unknown jq error}"
+  if echo "$JQ_TEST_ERROR" | grep -qi "cannot get entropy for arc4random"; then
+    echo "ERROR: Detected the Synology kernel entropy issue from #960. See https://github.com/homebridge/docker-homebridge/issues/960 for details."
+  fi
+  echo "ERROR: Stopping setup script to prevent potential issues with Homebridge setup."
   exit 1
 else
   echo "jq is functioning correctly, proceeding with setup"

--- a/rootfs/etc/s6-overlay/scripts/setup.sh
+++ b/rootfs/etc/s6-overlay/scripts/setup.sh
@@ -53,7 +53,7 @@ cd /homebridge
 
 # test jq is functioning correctly
 if ! JQ_TEST_ERROR="$(echo '{}' | jq . 2>&1 >/dev/null)"; then
-  echo "ERROR: jq failed during setup check: ${JQ_TEST_ERROR:-unknown jq error}"
+  echo "ERROR: jq failed during setup check: ${JQ_TEST_ERROR:-no error output captured}"
   if echo "$JQ_TEST_ERROR" | grep -qi "cannot get entropy for arc4random"; then
     echo "ERROR: Detected the Synology kernel entropy issue from #960. See https://github.com/homebridge/docker-homebridge/issues/960 for details."
   fi

--- a/rootfs/etc/s6-overlay/scripts/setup.sh
+++ b/rootfs/etc/s6-overlay/scripts/setup.sh
@@ -52,8 +52,8 @@ cd /homebridge
 
 
 # test jq is functioning correctly
-if ! JQ_TEST_ERROR="$(echo '{}' | jq . 2>&1 >/dev/null)"; then
-  echo "ERROR: jq failed during setup check: ${JQ_TEST_ERROR:-no error output captured}"
+if ! JQ_TEST_ERROR="$(jq -n '{}' 2>&1 >/dev/null)"; then
+  echo "ERROR: jq failed during setup check: ${JQ_TEST_ERROR:-jq test failed with no error output}"
   if echo "$JQ_TEST_ERROR" | grep -qi "cannot get entropy for arc4random"; then
     echo "ERROR: Detected the Synology kernel entropy issue from #960. See https://github.com/homebridge/docker-homebridge/issues/960 for details."
   fi

--- a/rootfs/etc/s6-overlay/scripts/setup.sh
+++ b/rootfs/etc/s6-overlay/scripts/setup.sh
@@ -52,13 +52,11 @@ cd /homebridge
 
 
 # test jq is functioning correctly
-JQ_TEST_ERROR="$(echo '{}' | jq . 2>&1 1>/dev/null)"
+JQ_TEST_ERROR="$(echo '{}' | jq . )"
 JQ_EXIT_CODE=$?
 if [ "$JQ_EXIT_CODE" -ne 0 ]; then
   echo "ERROR: jq failed during setup check: ${JQ_TEST_ERROR:-no error details captured}"
-  if echo "$JQ_TEST_ERROR" | grep -qi "cannot get entropy for arc4random"; then
-    echo "ERROR: Detected the Synology kernel entropy issue from #960. See https://github.com/homebridge/docker-homebridge/issues/960 for details."
-  fi
+  echo "ERROR: Detected the Synology kernel entropy issue from #960. See https://github.com/homebridge/docker-homebridge/issues/960 for details."
   echo "ERROR: Stopping setup script to prevent potential issues with Homebridge setup."
   exit 1
 else

--- a/rootfs/etc/s6-overlay/scripts/setup.sh
+++ b/rootfs/etc/s6-overlay/scripts/setup.sh
@@ -52,7 +52,7 @@ cd /homebridge
 
 
 # test jq is functioning correctly
-JQ_TEST_ERROR="$(echo '{}' | jq . 2>&1 >/dev/null)"
+JQ_TEST_ERROR="$(echo '{}' | jq . 2>&1 1>/dev/null)"
 JQ_EXIT_CODE=$?
 if [ "$JQ_EXIT_CODE" -ne 0 ]; then
   echo "ERROR: jq failed during setup check: ${JQ_TEST_ERROR:-no error details captured}"

--- a/rootfs/etc/s6-overlay/scripts/setup.sh
+++ b/rootfs/etc/s6-overlay/scripts/setup.sh
@@ -50,11 +50,14 @@ fi
 
 cd /homebridge
 
+
 # test jq is functioning correctly
 if ! echo '{}' | jq . > /dev/null 2>&1; then
-  echo "WARNING: jq is not functioning correctly - this may cause issues with Homebridge setup"
-  else
-  echo "jq is functioning correctly"
+  echo "ERROR: Issue detected with Host Kernel Version - see https://github.com/homebridge/docker-homebridge/issues/960 for details."
+  echo "ERROR: Stopping setup script to prevent potential issues with Homebridge setup. Please see the above link for details and a resolution."
+  exit 1
+else
+  echo "jq is functioning correctly, proceeding with setup"
 fi
 
 # set the .npmrc file

--- a/rootfs/etc/s6-overlay/scripts/setup.sh
+++ b/rootfs/etc/s6-overlay/scripts/setup.sh
@@ -52,7 +52,8 @@ cd /homebridge
 
 
 # test jq is functioning correctly
-if ! JQ_TEST_ERROR="$(printf '%s\n' '{}' | jq . 2>&1 >/dev/null)"; then
+JQ_TEST_ERROR="$(printf '%s\n' '{}' | jq . 2>&1 >/dev/null)"
+if [ $? -ne 0 ]; then
   echo "ERROR: jq failed during setup check: ${JQ_TEST_ERROR:-jq test failed without error details}"
   if echo "$JQ_TEST_ERROR" | grep -qi "cannot get entropy for arc4random"; then
     echo "ERROR: Detected the Synology kernel entropy issue from #960. See https://github.com/homebridge/docker-homebridge/issues/960 for details."

--- a/rootfs/etc/s6-overlay/scripts/setup.sh
+++ b/rootfs/etc/s6-overlay/scripts/setup.sh
@@ -52,10 +52,10 @@ cd /homebridge
 
 
 # test jq is functioning correctly
-JQ_TEST_ERROR="$(printf '%s\n' '{}' | jq . 2>&1 >/dev/null)"
+JQ_TEST_ERROR="$(echo '{}' | jq . 2>&1 >/dev/null)"
 JQ_EXIT_CODE=$?
 if [ "$JQ_EXIT_CODE" -ne 0 ]; then
-  echo "ERROR: jq failed during setup check: ${JQ_TEST_ERROR:-unknown error (no stderr output)}"
+  echo "ERROR: jq failed during setup check: ${JQ_TEST_ERROR:-no error details captured}"
   if echo "$JQ_TEST_ERROR" | grep -qi "cannot get entropy for arc4random"; then
     echo "ERROR: Detected the Synology kernel entropy issue from #960. See https://github.com/homebridge/docker-homebridge/issues/960 for details."
   fi

--- a/rootfs/etc/s6-overlay/scripts/setup.sh
+++ b/rootfs/etc/s6-overlay/scripts/setup.sh
@@ -52,8 +52,8 @@ cd /homebridge
 
 
 # test jq is functioning correctly
-if ! JQ_TEST_ERROR="$(jq -n '{}' 2>&1 >/dev/null)"; then
-  echo "ERROR: jq failed during setup check: ${JQ_TEST_ERROR:-jq test failed with no error output. This may indicate a system compatibility issue.}"
+if ! JQ_TEST_ERROR="$(printf '%s\n' '{}' | jq . 2>&1 >/dev/null)"; then
+  echo "ERROR: jq failed during setup check: ${JQ_TEST_ERROR:-jq test failed without error details}"
   if echo "$JQ_TEST_ERROR" | grep -qi "cannot get entropy for arc4random"; then
     echo "ERROR: Detected the Synology kernel entropy issue from #960. See https://github.com/homebridge/docker-homebridge/issues/960 for details."
   fi

--- a/rootfs/etc/s6-overlay/scripts/setup.sh
+++ b/rootfs/etc/s6-overlay/scripts/setup.sh
@@ -56,7 +56,7 @@ JQ_TEST_ERROR="$(echo '{}' | jq . )"
 JQ_EXIT_CODE=$?
 if [ "$JQ_EXIT_CODE" -ne 0 ]; then
   echo "ERROR: jq failed during setup check: ${JQ_TEST_ERROR:-no error details captured}"
-  echo "ERROR: Detected the Synology kernel entropy issue from #960. See https://github.com/homebridge/docker-homebridge/issues/960 for details."
+  echo "ERROR: See https://github.com/homebridge/docker-homebridge/issues/960 for details."
   echo "ERROR: Stopping setup script to prevent potential issues with Homebridge setup."
   exit 1
 else

--- a/rootfs/etc/s6-overlay/scripts/setup.sh
+++ b/rootfs/etc/s6-overlay/scripts/setup.sh
@@ -53,8 +53,9 @@ cd /homebridge
 
 # test jq is functioning correctly
 JQ_TEST_ERROR="$(printf '%s\n' '{}' | jq . 2>&1 >/dev/null)"
-if [ $? -ne 0 ]; then
-  echo "ERROR: jq failed during setup check: ${JQ_TEST_ERROR:-jq test failed without error details}"
+JQ_EXIT_CODE=$?
+if [ "$JQ_EXIT_CODE" -ne 0 ]; then
+  echo "ERROR: jq failed during setup check: ${JQ_TEST_ERROR:-unknown error (no stderr output)}"
   if echo "$JQ_TEST_ERROR" | grep -qi "cannot get entropy for arc4random"; then
     echo "ERROR: Detected the Synology kernel entropy issue from #960. See https://github.com/homebridge/docker-homebridge/issues/960 for details."
   fi

--- a/scripts/create-release-body.sh
+++ b/scripts/create-release-body.sh
@@ -105,7 +105,7 @@ elif [[ "${PKG_RELEASE_STREAM:-stable}" == "synology" ]]; then
   LATEST_TAG=$(git tag -l | grep -E "synology" | sort -V | tail -1 2>/dev/null || echo "")
 else
   # For stable releases, only look at stable tags (no beta, alpha, legacy, or synology in name)
-  LATEST_TAG=$(git tag -l | grep -v -E "(beta|alpha|legacy|synology|v)" | sort -V | tail -1 2>/dev/null || echo "")
+  LATEST_TAG=$(git tag -l | grep -v -E "(beta|alpha|legacy|synology)" | sort -V | tail -1 2>/dev/null || echo "")
 fi
 
 log "Latest tag for stream '${PKG_RELEASE_STREAM:-stable}': ${LATEST_TAG:-none}"

--- a/scripts/create-release-body.sh
+++ b/scripts/create-release-body.sh
@@ -97,9 +97,15 @@ if [[ "${PKG_RELEASE_STREAM:-stable}" == "beta" ]]; then
 elif [[ "${PKG_RELEASE_STREAM:-stable}" == "alpha" ]]; then
   # For alpha releases, only look at alpha tags
   LATEST_TAG=$(git tag -l | grep -E "alpha" | sort -V | tail -1 2>/dev/null || echo "")
+elif [[ "${PKG_RELEASE_STREAM:-stable}" == "legacy" ]]; then
+  # For legacy releases, only look at legacy tags
+  LATEST_TAG=$(git tag -l | grep -E "legacy" | sort -V | tail -1 2>/dev/null || echo "")
+elif [[ "${PKG_RELEASE_STREAM:-stable}" == "synology" ]]; then
+  # For synology releases, only look at synology tags
+  LATEST_TAG=$(git tag -l | grep -E "synology" | sort -V | tail -1 2>/dev/null || echo "")
 else
-  # For stable releases, only look at stable tags (no beta or alpha in name)
-  LATEST_TAG=$(git tag -l | grep -v -E "(beta|alpha|v)" | sort -V | tail -1 2>/dev/null || echo "")
+  # For stable releases, only look at stable tags (no beta, alpha, legacy, or synology in name)
+  LATEST_TAG=$(git tag -l | grep -v -E "(beta|alpha|legacy|synology|v)" | sort -V | tail -1 2>/dev/null || echo "")
 fi
 
 log "Latest tag for stream '${PKG_RELEASE_STREAM:-stable}': ${LATEST_TAG:-none}"
@@ -111,25 +117,19 @@ if [ -n "$LATEST_TAG" ]; then
   PACKAGE_JSON_PATH=""
   case "${PKG_RELEASE_STREAM:-stable}" in
     beta)
-      if [[ "$BUILD_ARCH" == "aarch64" || "$BUILD_ARCH" == "x86_64" ]]; then
-        PACKAGE_JSON_PATH="beta/package.json"
-      else
-        PACKAGE_JSON_PATH="beta/package.json"
-      fi
+      PACKAGE_JSON_PATH="beta/package.json"
       ;;
     alpha)
-      if [[ "$BUILD_ARCH" == "aarch64" || "$BUILD_ARCH" == "x86_64" ]]; then
-        PACKAGE_JSON_PATH="alpha/package.json"
-      else
-        PACKAGE_JSON_PATH="alpha/package.json"
-      fi
+      PACKAGE_JSON_PATH="alpha/package.json"
+      ;;
+    legacy)
+      PACKAGE_JSON_PATH="legacy/package.json"
+      ;;
+    synology)
+      PACKAGE_JSON_PATH="synology/package.json"
       ;;
     *)
-      if [[ "$BUILD_ARCH" == "aarch64" || "$BUILD_ARCH" == "x86_64" ]]; then
-        PACKAGE_JSON_PATH="package.json"
-      else
-        PACKAGE_JSON_PATH="package.json"
-      fi
+      PACKAGE_JSON_PATH="package.json"
       ;;
   esac
   

--- a/synology/package.json
+++ b/synology/package.json
@@ -2,7 +2,7 @@
   "name": "@homebridge/docker-homebridge",
   "private": true,
   "version": "0.0.0",
-  "description": "Stub file to track versions of homebridge-apt-pkg and ffmpeg-for-homebridge for the 'stable' release stream of the Docker image",
+  "description": "Stub file to track versions of homebridge-apt-pkg and ffmpeg-for-homebridge for the 'synology' release stream of the Docker image",
   "dependencies": {
     "@homebridge/homebridge-apt-pkg": "2.0.2",
     "ffmpeg-for-homebridge": "2.2.2"

--- a/synology/package.json
+++ b/synology/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@homebridge/docker-homebridge",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Stub file to track versions of homebridge-apt-pkg and ffmpeg-for-homebridge for the 'stable' release stream of the Docker image",
+  "dependencies": {
+    "@homebridge/homebridge-apt-pkg": "2.0.2",
+    "ffmpeg-for-homebridge": "2.2.2"
+  }
+}

--- a/test-build-local.sh
+++ b/test-build-local.sh
@@ -16,6 +16,7 @@ docker build -f ./Dockerfile \
   --build-arg HOMEBRIDGE_APT_PKG_VERSION=v${HOMEBRIDGE_APT_PKG_VERSION} \
   --build-arg FFMPEG_FOR_HOMEBRIDGE_VERSION=v${FFMPEG_FOR_HOMEBRIDGE_VERSION} \
   --build-arg DOCKER_HOMEBRIDGE_VERSION=${DOCKER_HOMEBRIDGE_VERSION} \
+  --build-arg BASE_IMAGE=22.04 \
   -t ${HOMEBRIDGE_IMAGE} .
 
 # Start container using docker-compose

--- a/test-build-local.sh
+++ b/test-build-local.sh
@@ -7,16 +7,20 @@ export DOCKER_HOMEBRIDGE_VERSION=$(date +'%Y-%m-%d')
 
 export HOMEBRIDGE_IMAGE='docker-homebridge'
 
+# Allow BASE_IMAGE to be overridden via environment variable (defaults to 24.04)
+export BASE_IMAGE=${BASE_IMAGE:-24.04}
+
 echo HOMEBRIDGE_APT_PKG_VERSION ${HOMEBRIDGE_APT_PKG_VERSION}
 echo FFMPEG_FOR_HOMEBRIDGE_VERSION ${FFMPEG_FOR_HOMEBRIDGE_VERSION}
 echo DOCKER_HOMEBRIDGE_VERSION ${DOCKER_HOMEBRIDGE_VERSION}
+echo BASE_IMAGE ${BASE_IMAGE}
 
 # Build Docker image
 docker build -f ./Dockerfile \
   --build-arg HOMEBRIDGE_APT_PKG_VERSION=v${HOMEBRIDGE_APT_PKG_VERSION} \
   --build-arg FFMPEG_FOR_HOMEBRIDGE_VERSION=v${FFMPEG_FOR_HOMEBRIDGE_VERSION} \
   --build-arg DOCKER_HOMEBRIDGE_VERSION=${DOCKER_HOMEBRIDGE_VERSION} \
-  --build-arg BASE_IMAGE=22.04 \
+  --build-arg BASE_IMAGE=${BASE_IMAGE} \
   -t ${HOMEBRIDGE_IMAGE} .
 
 # Start container using docker-compose

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   homebridge:
-    image: ${HOMEBRIDGE_IMAGE:-homebridge/homebridge:synology}
+    image: ${HOMEBRIDGE_IMAGE:-homebridge/homebridge:beta}
     hostname: test-homebridge-docker
     restart: always
     network_mode: host

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   homebridge:
-    image: ${HOMEBRIDGE_IMAGE:-homebridge/homebridge:legacy}
+    image: ${HOMEBRIDGE_IMAGE:-homebridge/homebridge:synology}
     hostname: test-homebridge-docker
     restart: always
     network_mode: host


### PR DESCRIPTION
Create new release stream Synology based on Ubuntu 22.04 as a workaround for jq failing with the message

```
Fatal glibc error: cannot get entropy for arc4random
Aborted (core dumped)
```

To the end user this appeared as plugins disappearing after updating the Docker container on Synology devices.

